### PR TITLE
Correct build command for Linux/Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ build
 ### Linux/Mac
 
 ```
-build.sh
+./build.sh
 ```
 
 This will generate the new font files in the `build` folder. You can now install these fonts on your system.


### PR DESCRIPTION
`./build.sh` instead of `build.sh`