### PR TITLE
Update insecure packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -27,7 +27,7 @@
       "resolved": "https://registry.npmjs.org/xml-formatter/-/xml-formatter-1.0.1.tgz",
       "integrity": "sha1-OAgz3dC86iwJht7+u6cfhDhPNT0=",
       "requires": {
-        "xml-parser-xo": "2.1.3"
+        "xml-parser-xo": "^2.1.1"
       }
     },
     "xml-parser-xo": {
@@ -35,7 +35,7 @@
       "resolved": "https://registry.npmjs.org/xml-parser-xo/-/xml-parser-xo-2.1.3.tgz",
       "integrity": "sha1-TqjrhW36TddcSrVLJRVY3grcHGE=",
       "requires": {
-        "debug": "2.6.8"
+        "debug": "^2.2.0"
       }
     },
     "xmldom": {


### PR DESCRIPTION
When running `npm audit`, [there is one low-severity security issue](https://nodesecurity.io/advisories/534)

Here's a change to the `package-lock.json` file to install the updated, secure package.