### PR TITLE
Bold italic ligatures

### DIFF
--- a/ligature/OperatorMonoSSmLig-Bold/config.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/config.xml
@@ -102,7 +102,7 @@
         <metricDataFormat value="0"/>
         
     
-        <numberOfHMetrics value="475"/>
+        <numberOfHMetrics value="478"/>
         
   
     </hhea>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/ampersand_ampersand.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/ampersand_ampersand.liga.xml
@@ -1,0 +1,63 @@
+<Glyph name="ampersand_ampersand.liga" lsb="-449" width="625">
+    <CharString>
+        -16 127 451 142 hstem
+        -449 149 267 131 23 160 166 131 vstem
+        491 224 rmoveto
+        {61b5daa5} callgsubr
+        {4301c904} callsubr
+        -79 -50 -50 -54 -13 -71 -24 30 rcurveline
+        {61b5daa5} callgsubr
+        {4301c904} callsubr
+        {2bd6a1b5} callsubr
+        -68 62 108 -31 121 hhcurveto
+        69 68 31 68 52 hvcurveto
+        23 -30 24 -33 25 -36 130 96 rcurveline
+        -41 55 -37 47 -33 42 rrcurveto
+        -724 -113 rmoveto
+        {a063a877} callsubr
+        480 hmoveto
+        {a063a877} callsubr
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="4301c904">
+            -88 104 -43 47 33 vvcurveto
+            44 30 18 133 -5 vhcurveto
+            -10 142 rlineto
+            -238 4 -75 -102 -102 vvcurveto
+            -43 20 -41 36 -51 vhcurveto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="4301c904">
+            -88 104 -43 47 33 vvcurveto
+            44 30 18 133 -5 vhcurveto
+            -10 142 rlineto
+            -238 4 -75 -102 -102 vvcurveto
+            -43 20 -41 36 -51 vhcurveto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="2bd6a1b5">
+            -94 -59 -52 -65 -93 vvcurveto
+            -96 59 -72 121 69 68 31 68 52 vhcurveto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="a063a877">
+            -45 -22 33 42 39 18 36 37 32 hvcurveto
+            28 -35 33 -40 38 -48 rrcurveto
+            -40 -27 -27 -19 -33 hhcurveto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="61b5daa5">
+            32 59 33 78 22 75 -131 16 rcurveline
+            -8 -39 -13 -48 -14 -44 rrcurveto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="61b5daa5">
+            32 59 33 78 22 75 -131 16 rcurveline
+            -8 -39 -13 -48 -14 -44 rrcurveto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/bar_bar.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/bar_bar.liga.xml
@@ -1,12 +1,11 @@
 <Glyph name="bar_bar.liga" lsb="-308" width="625">
     <CharString>
         -308 149 318 149 vstem
-        -159 806 {2dc5cb94} callgsubr
-        467 1010 {2dc5cb94} callgsubr
+        -159 806 {2dc5cb94} callsubr
+        467 1010 {2dc5cb94} callsubr
         endchar
     </CharString>
-    <Subrs/>
-    <GlobalSubrs>
+    <Subrs>
         <CharString index="0" fingerprint="2dc5cb94">
             rmoveto
             -149 -12 rlineto
@@ -19,5 +18,6 @@
             -998 149 vlineto
             return
         </CharString>
-    </GlobalSubrs>
+    </Subrs>
+    <GlobalSubrs/>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/bar_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/bar_greater.liga.xml
@@ -1,7 +1,7 @@
 <Glyph name="bar_greater.liga" lsb="-304" width="625">
     <CharString>
         -304 652 vstem
-        -155 806 {2dc5cb94} callgsubr
+        -155 806 {2dc5cb94} callsubr
         503 472 rlineto
         129 vlineto
         -141 -72 rmoveto
@@ -10,13 +10,13 @@
         362 -284 rlineto
         endchar
     </CharString>
-    <Subrs/>
-    <GlobalSubrs>
+    <Subrs>
         <CharString index="0" fingerprint="2dc5cb94">
             rmoveto
             -149 -12 rlineto
             -998 149 vlineto
             return
         </CharString>
-    </GlobalSubrs>
+    </Subrs>
+    <GlobalSubrs/>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/colon_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/colon_equal.liga.xml
@@ -1,0 +1,43 @@
+<Glyph name="colon_equal.liga" lsb="-450" width="625">
+    <CharString>
+        126 183 60 183 hstem
+        -450 907 vstem
+        -450 369 rmoveto
+        {567c0d9d} callgsubr
+        904 -158 {04aa7597} callgsubr
+        -597 {35032154} callsubr
+        -310 -268 rmoveto
+        {567c0d9d} callgsubr
+        904 -157 {04aa7597} callgsubr
+        -597 {35032154} callsubr
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="35032154">
+            -132 vlineto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="35032154">
+            -132 vlineto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="567c0d9d">
+            207 hlineto
+            3 183 rlineto
+            -207 hlineto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="04aa7597">
+            rmoveto
+            132 return
+        </CharString>
+        <CharString index="2" fingerprint="567c0d9d">
+            207 hlineto
+            3 183 rlineto
+            -207 hlineto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_equal.2.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_equal.2.liga.xml
@@ -4,30 +4,35 @@
         hstem
         -546 1091 vstem
         -30 394 rmoveto
-        {6c83893f} callgsubr
-        1091 {25b0bac7} callgsubr
+        {8ac6178e} callsubr
+        1091 {0e6bbb48} callsubr
         -59 -242 rmoveto
-        {6c83893f} callgsubr
-        1091 {25b0bac7} callgsubr
+        {8ac6178e} callsubr
+        1091 {0e6bbb48} callsubr
         endchar
     </CharString>
-    <Subrs/>
-    <GlobalSubrs>
-        <CharString index="0" fingerprint="b6a51f90">
-            152 132 110 132 return
-        </CharString>
-        <CharString index="1" fingerprint="6c83893f">
-            132 -516 {35032154} callgsubr
+    <Subrs>
+        <CharString index="0" fingerprint="8ac6178e">
+            132 -516 {35032154} callsubr
             return
         </CharString>
-        <CharString index="2" fingerprint="35032154">
+        <CharString index="1" fingerprint="35032154">
             -132 vlineto
             return
         </CharString>
-        <CharString index="3" fingerprint="25b0bac7">
+        <CharString index="2" fingerprint="0e6bbb48">
             hmoveto
-            {6c83893f} callgsubr
+            {8ac6178e} callsubr
             return
+        </CharString>
+        <CharString index="3" fingerprint="8ac6178e">
+            132 -516 {35032154} callsubr
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="b6a51f90">
+            152 132 110 132 return
         </CharString>
     </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_equal.liga.xml
@@ -4,14 +4,18 @@
         hstem
         -546 1091 vstem
         {2afc7c25} callgsubr
-        -1091 {35032154} callgsubr
-        1091 {2f6bf419} callsubr
-        -1091 {35032154} callgsubr
+        -1091 {35032154} callsubr
+        1091 -242 {04aa7597} callgsubr
+        -1091 {35032154} callsubr
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="2f6bf419">
-            -242 {04aa7597} callgsubr
+        <CharString index="0" fingerprint="35032154">
+            -132 vlineto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="35032154">
+            -132 vlineto
             return
         </CharString>
     </Subrs>
@@ -26,10 +30,6 @@
         <CharString index="2" fingerprint="04aa7597">
             rmoveto
             132 return
-        </CharString>
-        <CharString index="3" fingerprint="35032154">
-            -132 vlineto
-            return
         </CharString>
     </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_equal_equal.2.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_equal_equal.2.liga.xml
@@ -3,23 +3,27 @@
         {b6a51f90} callgsubr
         hstem
         -1171 1716 vstem
-        -655 394 {d9b0093f} callsubr
-        -684 -242 {d9b0093f} callsubr
+        -655 394 {ec225a2c} callgsubr
+        -684 -242 {ec225a2c} callgsubr
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="d9b0093f">
-            rmoveto
-            132 -516 -132 vlineto
-            1116 hmoveto
-            {4b301e1c} callgsubr
+        <CharString index="0" fingerprint="ebaf81b0">
+            {8ac6178e} callsubr
+            1116 {0e6bbb48} callsubr
             return
         </CharString>
-        <CharString index="1" fingerprint="d9b0093f">
-            rmoveto
-            132 -516 -132 vlineto
-            1116 hmoveto
-            {4b301e1c} callgsubr
+        <CharString index="1" fingerprint="8ac6178e">
+            132 -516 {35032154} callsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="35032154">
+            -132 vlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="0e6bbb48">
+            hmoveto
+            {8ac6178e} callsubr
             return
         </CharString>
     </Subrs>
@@ -27,22 +31,11 @@
         <CharString index="0" fingerprint="b6a51f90">
             152 132 110 132 return
         </CharString>
-        <CharString index="1" fingerprint="4b301e1c">
-            {6c83893f} callgsubr
-            1116 {25b0bac7} callgsubr
-            return
-        </CharString>
-        <CharString index="2" fingerprint="6c83893f">
-            132 -516 {35032154} callgsubr
-            return
-        </CharString>
-        <CharString index="3" fingerprint="35032154">
-            -132 vlineto
-            return
-        </CharString>
-        <CharString index="4" fingerprint="25b0bac7">
-            hmoveto
-            {6c83893f} callgsubr
+        <CharString index="1" fingerprint="ec225a2c">
+            rmoveto
+            132 -516 -132 vlineto
+            1116 hmoveto
+            {ebaf81b0} callsubr
             return
         </CharString>
     </GlobalSubrs>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_equal_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_equal_equal.liga.xml
@@ -3,20 +3,20 @@
         273 132 110 132 hstem
         -1091 1636 vstem
         545 515 {04aa7597} callgsubr
-        -1636 {35032154} callgsubr
-        1636 {2f6bf419} callsubr
-        -1636 {35032154} callgsubr
-        1636 {2f6bf419} callsubr
-        -1636 {35032154} callgsubr
+        -1636 {35032154} callsubr
+        1636 -242 {04aa7597} callgsubr
+        -1636 {35032154} callsubr
+        1636 -242 {04aa7597} callgsubr
+        -1636 {35032154} callsubr
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="2f6bf419">
-            -242 {04aa7597} callgsubr
+        <CharString index="0" fingerprint="35032154">
+            -132 vlineto
             return
         </CharString>
-        <CharString index="1" fingerprint="2f6bf419">
-            -242 {04aa7597} callgsubr
+        <CharString index="1" fingerprint="35032154">
+            -132 vlineto
             return
         </CharString>
     </Subrs>
@@ -25,11 +25,7 @@
             rmoveto
             132 return
         </CharString>
-        <CharString index="1" fingerprint="35032154">
-            -132 vlineto
-            return
-        </CharString>
-        <CharString index="2" fingerprint="04aa7597">
+        <CharString index="1" fingerprint="04aa7597">
             rmoveto
             132 return
         </CharString>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_equal_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_equal_greater.liga.xml
@@ -2,18 +2,31 @@
     <CharString>
         {b6a51f90} callgsubr
         hstemhm
-        -1171 1712 {7f892a4a} callsubr
-        -1329 -132 1500 {683f7f32} callgsubr
+        -1171 1712 {7200d27f} callsubr
+        -1329 -132 1500 {9a6ba509} callsubr
         -1518 -132 1349 hlineto
-        -90 -70 {00c9cf16} callsubr
+        -90 -70 {00c9cf16} callgsubr
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="7f892a4a">
+        <CharString index="0" fingerprint="7200d27f">
             -141 141 hintmask 11100000
-            {8890d024} callsubr
+            {8890d024} callgsubr
             69 -53 rlineto
             return
+        </CharString>
+        <CharString index="1" fingerprint="9a6ba509">
+            hlineto
+            hintmask 11010000
+            71 -55 rlineto
+            -14 vlineto
+            -53 -41 {bf847d0e} callgsubr
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="b6a51f90">
+            152 132 110 132 return
         </CharString>
         <CharString index="1" fingerprint="8890d024">
             177 693 rmoveto
@@ -27,19 +40,6 @@
         <CharString index="3" fingerprint="00c9cf16">
             83 -112 370 298 rlineto
             129 vlineto
-            return
-        </CharString>
-    </Subrs>
-    <GlobalSubrs>
-        <CharString index="0" fingerprint="b6a51f90">
-            152 132 110 132 return
-        </CharString>
-        <CharString index="1" fingerprint="683f7f32">
-            hlineto
-            hintmask 11010000
-            71 -55 rlineto
-            -14 vlineto
-            -53 -41 {bf847d0e} callsubr
             return
         </CharString>
     </GlobalSubrs>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_greater.liga.xml
@@ -2,18 +2,31 @@
     <CharString>
         {b6a51f90} callgsubr
         hstemhm
-        -546 1087 {7f892a4a} callsubr
-        -704 -132 875 {683f7f32} callgsubr
+        -546 1087 {7200d27f} callsubr
+        -704 -132 875 {9a6ba509} callsubr
         -893 -132 724 hlineto
-        -90 -70 {00c9cf16} callsubr
+        -90 -70 {00c9cf16} callgsubr
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="7f892a4a">
+        <CharString index="0" fingerprint="7200d27f">
             -141 141 hintmask 11100000
-            {8890d024} callsubr
+            {8890d024} callgsubr
             69 -53 rlineto
             return
+        </CharString>
+        <CharString index="1" fingerprint="9a6ba509">
+            hlineto
+            hintmask 11010000
+            71 -55 rlineto
+            -14 vlineto
+            -53 -41 {bf847d0e} callgsubr
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="b6a51f90">
+            152 132 110 132 return
         </CharString>
         <CharString index="1" fingerprint="8890d024">
             177 693 rmoveto
@@ -27,19 +40,6 @@
         <CharString index="3" fingerprint="00c9cf16">
             83 -112 370 298 rlineto
             129 vlineto
-            return
-        </CharString>
-    </Subrs>
-    <GlobalSubrs>
-        <CharString index="0" fingerprint="b6a51f90">
-            152 132 110 132 return
-        </CharString>
-        <CharString index="1" fingerprint="683f7f32">
-            hlineto
-            hintmask 11010000
-            71 -55 rlineto
-            -14 vlineto
-            -53 -41 {bf847d0e} callsubr
             return
         </CharString>
     </GlobalSubrs>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_less_less.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/equal_less_less.liga.xml
@@ -4,8 +4,8 @@
         hstemhm
         -1171 1712 -872 141 278 141 hintmask 11010000
         -190 339 rmoveto
-        {a6f5fb2a} callgsubr
-        -209 -168 {bf847d0e} callsubr
+        {a6f5fb2a} callsubr
+        -209 -168 {bf847d0e} callgsubr
         -1001 -132 hlineto
         hintmask 11010000
         840 -110 hlineto
@@ -17,39 +17,37 @@
         hintmask 11011000
         419 14 rmoveto
         hintmask 11100000
-        {a6f5fb2a} callgsubr
+        {a6f5fb2a} callsubr
         rlineto
         hintmask 11011000
         {822f0283} callsubr
-        {bf847d0e} callsubr
+        {bf847d0e} callgsubr
         88 113 rlineto
         hintmask 11011000
         -311 241 rlineto
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="bf847d0e">
-            rlineto
-            hintmask 11100000
-            return
+        <CharString index="0" fingerprint="a6f5fb2a">
+            312 243 -83 112 return
         </CharString>
-        <CharString index="1" fingerprint="822f0283">
+        <CharString index="1" fingerprint="a6f5fb2a">
+            312 243 -83 112 return
+        </CharString>
+        <CharString index="2" fingerprint="822f0283">
             -370 -298 rlineto
             -130 vlineto
             364 -295 return
-        </CharString>
-        <CharString index="2" fingerprint="bf847d0e">
-            rlineto
-            hintmask 11100000
-            return
         </CharString>
     </Subrs>
     <GlobalSubrs>
         <CharString index="0" fingerprint="b6a51f90">
             152 132 110 132 return
         </CharString>
-        <CharString index="1" fingerprint="a6f5fb2a">
-            312 243 -83 112 return
+        <CharString index="1" fingerprint="bf847d0e">
+            rlineto
+            hintmask 11100000
+            return
         </CharString>
     </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/greater_equal_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/greater_equal_greater.liga.xml
@@ -3,18 +3,18 @@
         {b6a51f90} callgsubr
         hstemhm
         -1162 1703 -1391 141 1109 141 hintmask 11010000
-        {8890d024} callsubr
+        {8890d024} callgsubr
         69 -53 rlineto
         -1026 hlineto
-        -205 167 {bf847d0e} callsubr
+        -205 167 {bf847d0e} callgsubr
         -88 -114 rlineto
         hintmask 11010000
-        {e525c5a7} callsubr
+        {e525c5a7} callgsubr
         hintmask 11100000
         {64c17bc4} callsubr
         226 182 rlineto
         1031 hlineto
-        -90 -70 {00c9cf16} callsubr
+        -90 -70 {00c9cf16} callgsubr
         hintmask 11011000
         -141 -72 rmoveto
         -53 -41 rlineto
@@ -23,32 +23,32 @@
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="8890d024">
-            177 693 rmoveto
-            -88 -114 return
-        </CharString>
-        <CharString index="1" fingerprint="bf847d0e">
-            rlineto
-            hintmask 11100000
-            return
-        </CharString>
-        <CharString index="2" fingerprint="e525c5a7">
-            311 -240 rlineto
-            -14 vlineto
-            return
-        </CharString>
-        <CharString index="3" fingerprint="64c17bc4">
+        <CharString index="0" fingerprint="64c17bc4">
             -312 -243 83 -112 return
-        </CharString>
-        <CharString index="4" fingerprint="00c9cf16">
-            83 -112 370 298 rlineto
-            129 vlineto
-            return
         </CharString>
     </Subrs>
     <GlobalSubrs>
         <CharString index="0" fingerprint="b6a51f90">
             152 132 110 132 return
+        </CharString>
+        <CharString index="1" fingerprint="8890d024">
+            177 693 rmoveto
+            -88 -114 return
+        </CharString>
+        <CharString index="2" fingerprint="bf847d0e">
+            rlineto
+            hintmask 11100000
+            return
+        </CharString>
+        <CharString index="3" fingerprint="e525c5a7">
+            311 -240 rlineto
+            -14 vlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="00c9cf16">
+            83 -112 370 298 rlineto
+            129 vlineto
+            return
         </CharString>
     </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/greater_greater_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/greater_greater_equal.liga.xml
@@ -4,52 +4,50 @@
         hstemhm
         -1162 1707 -1395 141 279 141 hintmask 11011000
         -709 397 rmoveto
-        -364 296 {bf847d0e} callsubr
+        -364 296 {bf847d0e} callgsubr
         -88 -114 rlineto
         hintmask 11011000
-        {e525c5a7} callsubr
+        {e525c5a7} callgsubr
         hintmask 11100000
         {64c17bc4} callsubr
         rlineto
         hintmask 11011000
-        370 298 {bf847d0e} callsubr
+        370 298 {bf847d0e} callgsubr
         1254 126 {04aa7597} callgsubr
         -993 vlineto
         -205 167 -88 -114 rlineto
         hintmask 11011000
-        {e525c5a7} callsubr
+        {e525c5a7} callgsubr
         {64c17bc4} callsubr
-        226 182 {bf847d0e} callsubr
+        226 182 {bf847d0e} callgsubr
         978 132 hlineto
         hintmask 11011000
         -834 110 hlineto
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="bf847d0e">
-            rlineto
-            hintmask 11100000
-            return
-        </CharString>
-        <CharString index="1" fingerprint="e525c5a7">
-            311 -240 rlineto
-            -14 vlineto
-            return
-        </CharString>
-        <CharString index="2" fingerprint="64c17bc4">
+        <CharString index="0" fingerprint="64c17bc4">
             -312 -243 83 -112 return
         </CharString>
-        <CharString index="3" fingerprint="bf847d0e">
-            rlineto
-            hintmask 11100000
-            return
+        <CharString index="1" fingerprint="64c17bc4">
+            -312 -243 83 -112 return
         </CharString>
     </Subrs>
     <GlobalSubrs>
         <CharString index="0" fingerprint="b6a51f90">
             152 132 110 132 return
         </CharString>
-        <CharString index="1" fingerprint="04aa7597">
+        <CharString index="1" fingerprint="bf847d0e">
+            rlineto
+            hintmask 11100000
+            return
+        </CharString>
+        <CharString index="2" fingerprint="e525c5a7">
+            311 -240 rlineto
+            -14 vlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="04aa7597">
             rmoveto
             132 return
         </CharString>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/hyphen_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/hyphen_greater.liga.xml
@@ -2,10 +2,10 @@
     <CharString>
         269 {2372f2aa} callsubr
         -489 1030 vstem
-        {8890d024} callsubr
+        {8890d024} callgsubr
         228 -176 rlineto
         -806 -134 817 hlineto
-        -240 -187 {00c9cf16} callsubr
+        -240 -187 {00c9cf16} callgsubr
         endchar
     </CharString>
     <Subrs>
@@ -13,15 +13,16 @@
             134 hstem
             return
         </CharString>
-        <CharString index="1" fingerprint="8890d024">
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="8890d024">
             177 693 rmoveto
             -88 -114 return
         </CharString>
-        <CharString index="2" fingerprint="00c9cf16">
+        <CharString index="1" fingerprint="00c9cf16">
             83 -112 370 298 rlineto
             129 vlineto
             return
         </CharString>
-    </Subrs>
-    <GlobalSubrs/>
+    </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/hyphen_hyphen.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/hyphen_hyphen.liga.xml
@@ -3,9 +3,9 @@
         269 {2372f2aa} callsubr
         -415 361 108 361 vstem
         -68 269 rmoveto
-        {93ba709a} callgsubr
+        {93ba709a} callsubr
         816 hmoveto
-        {93ba709a} callgsubr
+        {93ba709a} callsubr
         endchar
     </CharString>
     <Subrs>
@@ -13,17 +13,11 @@
             134 hstem
             return
         </CharString>
-    </Subrs>
-    <GlobalSubrs>
-        <CharString index="0" fingerprint="93ba709a">
-            14 134 rlineto
-            -361 -134 hlineto
-            return
-        </CharString>
         <CharString index="1" fingerprint="93ba709a">
             14 134 rlineto
             -361 -134 hlineto
             return
         </CharString>
-    </GlobalSubrs>
+    </Subrs>
+    <GlobalSubrs/>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/hyphen_hyphen_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/hyphen_hyphen_greater.liga.xml
@@ -2,10 +2,10 @@
     <CharString>
         269 {2372f2aa} callsubr
         -1114 1655 vstem
-        {8890d024} callsubr
+        {8890d024} callgsubr
         228 -176 rlineto
         -1431 -134 1442 hlineto
-        -240 -187 {00c9cf16} callsubr
+        -240 -187 {00c9cf16} callgsubr
         endchar
     </CharString>
     <Subrs>
@@ -13,15 +13,16 @@
             134 hstem
             return
         </CharString>
-        <CharString index="1" fingerprint="8890d024">
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="8890d024">
             177 693 rmoveto
             -88 -114 return
         </CharString>
-        <CharString index="2" fingerprint="00c9cf16">
+        <CharString index="1" fingerprint="00c9cf16">
             83 -112 370 298 rlineto
             129 vlineto
             return
         </CharString>
-    </Subrs>
-    <GlobalSubrs/>
+    </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/less_equal_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/less_equal_equal.liga.xml
@@ -6,7 +6,7 @@
         -950 394 rmoveto
         hintmask 11010000
         1495 132 -1326 hlineto
-        72 56 -83 112 {bf847d0e} callsubr
+        72 56 -83 112 {bf847d0e} callgsubr
         {822f0283} callsubr
         88 113 -88 68 rlineto
         hintmask 11010000
@@ -17,12 +17,7 @@
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="bf847d0e">
-            rlineto
-            hintmask 11100000
-            return
-        </CharString>
-        <CharString index="1" fingerprint="822f0283">
+        <CharString index="0" fingerprint="822f0283">
             -370 -298 rlineto
             -130 vlineto
             364 -295 return
@@ -31,6 +26,11 @@
     <GlobalSubrs>
         <CharString index="0" fingerprint="b6a51f90">
             152 132 110 132 return
+        </CharString>
+        <CharString index="1" fingerprint="bf847d0e">
+            rlineto
+            hintmask 11100000
+            return
         </CharString>
     </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/less_equal_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/less_equal_greater.liga.xml
@@ -2,7 +2,7 @@
     <CharString>
         {b6a51f90} callgsubr
         hstemhm
-        -1162 141 -141 1703 {7f892a4a} callsubr
+        -1162 141 -141 1703 {7200d27f} callsubr
         -939 hlineto
         72 56 -83 112 {822f0283} callsubr
         88 113 -88 68 rlineto
@@ -23,17 +23,13 @@
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="7f892a4a">
+        <CharString index="0" fingerprint="7200d27f">
             -141 141 hintmask 11100000
-            {8890d024} callsubr
+            {8890d024} callgsubr
             69 -53 rlineto
             return
         </CharString>
-        <CharString index="1" fingerprint="8890d024">
-            177 693 rmoveto
-            -88 -114 return
-        </CharString>
-        <CharString index="2" fingerprint="822f0283">
+        <CharString index="1" fingerprint="822f0283">
             -370 -298 rlineto
             -130 vlineto
             364 -295 return
@@ -42,6 +38,10 @@
     <GlobalSubrs>
         <CharString index="0" fingerprint="b6a51f90">
             152 132 110 132 return
+        </CharString>
+        <CharString index="1" fingerprint="8890d024">
+            177 693 rmoveto
+            -88 -114 return
         </CharString>
     </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/less_equal_less.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/less_equal_less.liga.xml
@@ -5,10 +5,10 @@
         -1162 141 -141 1703 -453 141 hintmask 11101000
         229 339 rmoveto
         hintmask 11010000
-        {a6f5fb2a} callgsubr
+        {a6f5fb2a} callsubr
         -209 -168 rlineto
         -1030 hlineto
-        72 56 -83 112 {bf847d0e} callsubr
+        72 56 -83 112 {bf847d0e} callgsubr
         {822f0283} callsubr
         88 113 -88 68 rlineto
         hintmask 11101000
@@ -25,10 +25,8 @@
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="bf847d0e">
-            rlineto
-            hintmask 11100000
-            return
+        <CharString index="0" fingerprint="a6f5fb2a">
+            312 243 -83 112 return
         </CharString>
         <CharString index="1" fingerprint="822f0283">
             -370 -298 rlineto
@@ -40,8 +38,10 @@
         <CharString index="0" fingerprint="b6a51f90">
             152 132 110 132 return
         </CharString>
-        <CharString index="1" fingerprint="a6f5fb2a">
-            312 243 -83 112 return
+        <CharString index="1" fingerprint="bf847d0e">
+            rlineto
+            hintmask 11100000
+            return
         </CharString>
     </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/less_exclam_hyphen_hyphen.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/less_exclam_hyphen_hyphen.liga.xml
@@ -2,7 +2,7 @@
     <CharString>
         0 169 100 {2372f2aa} callsubr
         -1787 141 656 193 vstem
-        -940 {039eaf0e} callsubr
+        -940 {039eaf0e} callgsubr
         -353 -171 rmoveto
         -83 112 {822f0283} callsubr
         88 113 -239 185 rlineto
@@ -12,32 +12,33 @@
         850 hmoveto
         -134 1197 vlineto
         14 134 rlineto
-        -1489 -403 {100d8e6f} callsubr
+        -1489 -403 {100d8e6f} callgsubr
     </CharString>
     <Subrs>
         <CharString index="0" fingerprint="2372f2aa">
             134 hstem
             return
         </CharString>
-        <CharString index="1" fingerprint="039eaf0e">
+        <CharString index="1" fingerprint="822f0283">
+            -370 -298 rlineto
+            -130 vlineto
+            364 -295 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="039eaf0e">
             284 rmoveto
             106 hlineto
             55 469 rlineto
             -202 hlineto
             return
         </CharString>
-        <CharString index="2" fingerprint="822f0283">
-            -370 -298 rlineto
-            -130 vlineto
-            364 -295 return
-        </CharString>
-        <CharString index="3" fingerprint="100d8e6f">
+        <CharString index="1" fingerprint="100d8e6f">
             rmoveto
             193 hlineto
             4 169 rlineto
             -193 hlineto
             endchar
         </CharString>
-    </Subrs>
-    <GlobalSubrs/>
+    </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/less_slash.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/less_slash.liga.xml
@@ -5,21 +5,20 @@
         257 838 rmoveto
         -365 -736 -288 223 rlineto
         14 vlineto
-        {a6f5fb2a} callgsubr
+        {a6f5fb2a} callsubr
         {822f0283} callsubr
         -71 -142 136 -64 500 1009 rlineto
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="822f0283">
+        <CharString index="0" fingerprint="a6f5fb2a">
+            312 243 -83 112 return
+        </CharString>
+        <CharString index="1" fingerprint="822f0283">
             -370 -298 rlineto
             -130 vlineto
             364 -295 return
         </CharString>
     </Subrs>
-    <GlobalSubrs>
-        <CharString index="0" fingerprint="a6f5fb2a">
-            312 243 -83 112 return
-        </CharString>
-    </GlobalSubrs>
+    <GlobalSubrs/>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/question_question.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/question_question.liga.xml
@@ -6,8 +6,8 @@
         {a2ee077c} callsubr
         480 hmoveto
         {a2ee077c} callsubr
-        -419 -755 {97a6c5e4} callsubr
-        475 -167 {97a6c5e4} callsubr
+        -419 -755 {97a6c5e4} callgsubr
+        475 -167 {97a6c5e4} callgsubr
         endchar
     </CharString>
     <Subrs>
@@ -29,13 +29,21 @@
             92 -96 75 -346 15 vhcurveto
             return
         </CharString>
-        <CharString index="2" fingerprint="97a6c5e4">
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="97a6c5e4">
             rmoveto
             191 hlineto
             4 167 rlineto
             -190 hlineto
             return
         </CharString>
-    </Subrs>
-    <GlobalSubrs/>
+        <CharString index="1" fingerprint="97a6c5e4">
+            rmoveto
+            191 hlineto
+            4 167 rlineto
+            -190 hlineto
+            return
+        </CharString>
+    </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/slash_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/slash_greater.liga.xml
@@ -6,19 +6,18 @@
         40 81 {511654ac} callgsubr
         394 796 288 -222 rlineto
         -14 vlineto
-        -312 -243 {00c9cf16} callsubr
+        -312 -243 {00c9cf16} callgsubr
         endchar
     </CharString>
-    <Subrs>
-        <CharString index="0" fingerprint="00c9cf16">
-            83 -112 370 298 rlineto
-            129 vlineto
-            return
-        </CharString>
-    </Subrs>
+    <Subrs/>
     <GlobalSubrs>
         <CharString index="0" fingerprint="511654ac">
             -135 64 -501 -1009 136 -64 return
+        </CharString>
+        <CharString index="1" fingerprint="00c9cf16">
+            83 -112 370 298 rlineto
+            129 vlineto
+            return
         </CharString>
     </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/glyphs/uniE0A0.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/glyphs/uniE0A0.xml
@@ -28,26 +28,26 @@
         71 -57 57 -71 vhcurveto
         hintmask 1110110110100000
         -384 63 rmoveto
-        35 29 -29 -35 -35 -29 -29 -35 {0f5e6060} callgsubr
+        35 29 -29 -35 -35 -29 -29 -35 {0f5e6060} callsubr
         hvcurveto
         384 -256 rmoveto
         hintmask 1101101010100000
-        {0f5e6060} callgsubr
+        {0f5e6060} callsubr
         35 29 -29 -35 hvcurveto
         hintmask 1110110110100000
         -35 -29 -29 -35 vhcurveto
         -384 -512 rmoveto
-        {0f5e6060} callgsubr
+        {0f5e6060} callsubr
         35 29 -29 -35 -35 -29 -29 -35 hvcurveto
         endchar
     </CharString>
-    <Subrs/>
-    <GlobalSubrs>
+    <Subrs>
         <CharString index="0" fingerprint="0f5e6060">
             -35 -29 29 35 35 29 29 35 return
         </CharString>
         <CharString index="1" fingerprint="0f5e6060">
             -35 -29 29 35 35 29 29 35 return
         </CharString>
-    </GlobalSubrs>
+    </Subrs>
+    <GlobalSubrs/>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-Bold/gsubrs.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/gsubrs.xml
@@ -22,7 +22,7 @@
         -64 -228 -56 -231 -54 -229 rrcurveto
         163 hlineto
         12 56 11 58 12 57 rrcurveto
-        4 callsubr
+        175 hlineto
         12 -60 12 -59 11 -58 rrcurveto
         -127 563 rmoveto
         10 hlineto
@@ -84,7 +84,7 @@
         -160 hlineto
         247 -161 rmoveto
         158 hlineto
-        -43 callgsubr
+        -40 callgsubr
         -160 hlineto
         return
       
@@ -251,7 +251,7 @@
         -2 107 -1 80 -2 72 65 24 73 13 80 3 -6 168 rcurveline
         -97 -14 -74 -47 -48 -60 -11 98 rcurveline
         -249 hlineto
-        -12 -24 callsubr
+        -12 -21 callgsubr
         -9 2 -88 1 -101 1 -134 rlinecurve
         -124 hlineto
         return
@@ -390,7 +390,7 @@
     <CharString index="25">
         
         88 286 87 hstemhm
-        125 118 -24 callsubr
+        125 118 -21 callgsubr
         121 116 -115 124 hintmask 11011000
         303 return
       
@@ -456,7 +456,7 @@
       
     <CharString index="31">
         
-        -37 callgsubr
+        -34 callsubr
         -165 660 -308 hlineto
         -13 -113 162 -9 rlineto
         -538 -164 vlineto
@@ -496,7 +496,7 @@
     <CharString index="35">
         
         hstem
-        74 157 -28 callsubr
+        74 157 -26 callsubr
         vstem
         return
       
@@ -514,7 +514,7 @@
       
     <CharString index="37">
         
-        144 566 -29 callsubr
+        144 566 -25 callsubr
         -101 callgsubr
         return
       
@@ -523,7 +523,7 @@
       
     <CharString index="38">
         
-        -21 callsubr
+        -16 callsubr
         hstem
         46 169 195 169 vstem
         return
@@ -533,30 +533,34 @@
       
     <CharString index="39">
         
-        -259 122 hstemhm
-        162 150 -150 275 hintmask 10100000
-        437 hmoveto
-        -40 59 rlineto
-        hintmask 11000000
-        -165 -70 -70 -64 -62 vvcurveto
-        -63 70 -54 180 -5 vhcurveto
-        -14 callsubr
-        -83 6 -5 callsubr
-        hintmask 10100000
-        23 30 30 95 38 vhcurveto
-        endchar
+        78 111 94 hstem
+        121 116 147 118 vstem
+        174 return
       
     </CharString>
     
       
     <CharString index="40">
         
-        171 118 268 131 return
+        83 -112 370 298 rlineto
+        129 vlineto
+        return
       
     </CharString>
     
       
     <CharString index="41">
+        
+        rmoveto
+        182 -226 111 90 -173 219 179 210 -111 91 -181 -231 rlineto
+        272 -153 rmoveto
+        182 -226 111 90 -176 217 181 212 -111 91 -181 -231 rlineto
+        endchar
+      
+    </CharString>
+    
+      
+    <CharString index="42">
         
         100 262 99 hstem
         107 124 161 123 vstem
@@ -565,7 +569,7 @@
     </CharString>
     
       
-    <CharString index="42">
+    <CharString index="43">
         
         492 619 -104 callgsubr
         return
@@ -573,7 +577,7 @@
     </CharString>
     
       
-    <CharString index="43">
+    <CharString index="44">
         
         vstem
         297 232 rmoveto
@@ -588,7 +592,7 @@
     </CharString>
     
       
-    <CharString index="44">
+    <CharString index="45">
         
         hstem
         64 156 169 154 vstem
@@ -597,7 +601,7 @@
     </CharString>
     
       
-    <CharString index="45">
+    <CharString index="46">
         
         rmoveto
         -107 93 rlineto
@@ -611,7 +615,7 @@
     </CharString>
     
       
-    <CharString index="46">
+    <CharString index="47">
         
         -16 127 466 127 hstem
         54 148 220 149 vstem
@@ -622,7 +626,7 @@
     </CharString>
     
       
-    <CharString index="47">
+    <CharString index="48">
         
         103 239 108 hstem
         354 125 vstem
@@ -631,26 +635,22 @@
     </CharString>
     
       
-    <CharString index="48">
-        
-        127 92 114 127 return
-      
-    </CharString>
-    
-      
     <CharString index="49">
         
-        -9 140 420 144 -139 139 hstemhm
-        85 171 return
+        95 110 78 hstem
+        121 118 148 115 vstem
+        311 return
       
     </CharString>
     
       
     <CharString index="50">
         
-        438 hlineto
-        13 135 rlineto
-        -286 553 -165 hlineto
+        280 281 rmoveto
+        148 -291 176 20 -188 347 172 331 rlineto
+        -173 hlineto
+        -130 -272 rlineto
+        -44 272 -163 -688 163 281 hlineto
         return
       
     </CharString>
@@ -658,275 +658,22 @@
       
     <CharString index="51">
         
-        553 182 135 -524 vlineto
-        -11 -135 rlineto
-        188 -553 hlineto
-        return
+        -49 callsubr
+        hstem
+        165 106 106 115 vstem
+        492 return
       
     </CharString>
     
       
     <CharString index="52">
         
-        223 113 228 -34 callsubr
-        84 161 151 5 callgsubr
-        return
+        0 125 438 125 return
       
     </CharString>
     
       
     <CharString index="53">
-        
-        0 118 543 118 hstem
-        3 callsubr
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="54">
-        
-        0 219 hstem
-        36 165 233 157 vstem
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="55">
-        
-        hmoveto
-        -46 callgsubr
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="56">
-        
-        110 238 103 return
-      
-    </CharString>
-    
-      
-    <CharString index="57">
-        
-        105 hstem
-        137 364 vstem
-        181 return
-      
-    </CharString>
-    
-      
-    <CharString index="58">
-        
-        hstem
-        231 -11 callgsubr
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="59">
-        
-        hstem
-        232 164 vstem
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="60">
-        
-        vlineto
-        356 -47 145 138 265 vvcurveto
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="61">
-        
-        132 -516 -34 callgsubr
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="62">
-        
-        rmoveto
-        -149 -12 rlineto
-        -998 149 vlineto
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="63">
-        
-        rmoveto
-        104 -110 249 231 10 153 -251 226 -104 -110 228 -195 rlineto
-        endchar
-      
-    </CharString>
-    
-      
-    <CharString index="64">
-        
-        5 161 rlineto
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="65">
-        
-        -20 callgsubr
-        84 100 return
-      
-    </CharString>
-    
-      
-    <CharString index="66">
-        
-        38 60 -80 71 hhcurveto
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="67">
-        
-        -10 132 302 145 hstem
-        78 157 vstem
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="68">
-        
-        0 137 288 137 hstem
-        74 482 vstem
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="69">
-        
-        0 140 409 139 hstem
-        72 490 vstem
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="70">
-        
-        475 -42 callsubr
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="71">
-        
-        rmoveto
-        81 -24 rlineto
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="72">
-        
-        rmoveto
-        -226 hlineto
-        -11 -125 rlineto
-        388 979 -381 -124 230 hlineto
-        endchar
-      
-    </CharString>
-    
-      
-    <CharString index="73">
-        
-        -132 vlineto
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="74">
-        
-        rmoveto
-        -81 25 -65 -58 -39 -103 -1 -92 rlinecurve
-        184 8 -19 68 2 85 19 67 rlinecurve
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="75">
-        
-        3 callgsubr
-        271 119 return
-      
-    </CharString>
-    
-      
-    <CharString index="76">
-        
-        0 135 hstem
-        111 165 return
-      
-    </CharString>
-    
-      
-    <CharString index="77">
-        
-        -6 callsubr
-        72 100 return
-      
-    </CharString>
-    
-      
-    <CharString index="78">
-        
-        hstem
-        26 574 vstem
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="79">
-        
-        107 242 102 return
-      
-    </CharString>
-    
-      
-    <CharString index="80">
-        
-        0 134 30 118 4 118 150 -34 callsubr
-        289 131 vstem
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="81">
-        
-        118 rlineto
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="82">
         
         207 hlineto
         3 183 rlineto
@@ -936,18 +683,278 @@
     </CharString>
     
       
+    <CharString index="54">
+        
+        319 443 -74 callsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="55">
+        
+        32 59 33 78 22 75 -131 16 rcurveline
+        -8 -39 -13 -48 -14 -44 rrcurveto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="56">
+        
+        0 118 543 118 hstem
+        7 callgsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="57">
+        
+        -33 callsubr
+        hstem
+        271 119 vstem
+        147 return
+      
+    </CharString>
+    
+      
+    <CharString index="58">
+        
+        177 693 rmoveto
+        -88 -114 return
+      
+    </CharString>
+    
+      
+    <CharString index="59">
+        
+        443 134 -20 20 hstemhm
+        80 158 156 158 hintmask 10110000
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="60">
+        
+        hstem
+        231 -8 callgsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="61">
+        
+        125 -45 125 hstemhm
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="62">
+        
+        -9 119 -118 128 122 91 105 130 -124 128 hstemhm
+        29 143 70 129 81 142 hintmask 01101111
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="63">
+        
+        rmoveto
+        132 -516 -132 vlineto
+        1116 hmoveto
+        -20 callsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="64">
+        
+        rmoveto
+        250 -226 105 110 -228 195 236 195 -105 110 -248 -231 rlineto
+        endchar
+      
+    </CharString>
+    
+      
+    <CharString index="65">
+        
+        hintmask 1000010001001000111100010001000010101100
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="66">
+        
+        40 24 53 60 60 vhcurveto
+        18 -48 24 -51 30 -53 rrcurveto
+        -40 -44 -38 -15 -28 hhcurveto
+        -29 -17 16 38 hvcurveto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="67">
+        
+        5 161 rlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="68">
+        
+        -15 callgsubr
+        84 100 return
+      
+    </CharString>
+    
+      
+    <CharString index="69">
+        
+        hlineto
+        13 -23 callgsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="70">
+        
+        1061 hstemhm
+        145 152 -151 157 -58 151 -143 140 hintmask 10001000
+        494 return
+      
+    </CharString>
+    
+      
+    <CharString index="71">
+        
+        -8 141 411 155 hstem
+        69 170 vstem
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="72">
+        
+        0 140 409 139 hstem
+        72 490 vstem
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="73">
+        
+        hintmask 1000010001001000111100010011000010101100
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="74">
+        
+        36 67 10 188 -16 vhcurveto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="75">
+        
+        rmoveto
+        81 -24 rlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="76">
+        
+        rmoveto
+        -979 376 vlineto
+        15 125 rlineto
+        -240 730 232 124 hlineto
+        endchar
+      
+    </CharString>
+    
+      
+    <CharString index="77">
+        
+        rlineto
+        36 49 25 64 74 vvcurveto
+        137 -89 86 -202 -27 vhcurveto
+        -687 118 vlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="78">
+        
+        rmoveto
+        191 hlineto
+        4 167 rlineto
+        -190 hlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="79">
+        
+        -3 callgsubr
+        72 100 return
+      
+    </CharString>
+    
+      
+    <CharString index="80">
+        
+        -165 -31 -62 -144 20 vhcurveto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="81">
+        
+        hstem
+        26 574 vstem
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="82">
+        
+        107 242 102 return
+      
+    </CharString>
+    
+      
     <CharString index="83">
         
-        17 26 28 10 32 hhcurveto
-        endchar
+        0 134 30 118 4 118 150 -31 callsubr
+        289 131 vstem
+        return
       
     </CharString>
     
       
     <CharString index="84">
         
-        -46 callgsubr
-        1116 -52 callgsubr
+        118 rlineto
         return
       
     </CharString>
@@ -955,8 +962,9 @@
       
     <CharString index="85">
         
-        111 hmoveto
-        -57 callgsubr
+        145 hlineto
+        7 194 rlineto
+        -146 hlineto
         return
       
     </CharString>
@@ -964,14 +972,15 @@
       
     <CharString index="86">
         
-        72 147 188 147 return
+        -112 124 return
       
     </CharString>
     
       
     <CharString index="87">
         
-        -246 -51 callgsubr
+        111 hmoveto
+        -56 callsubr
         return
       
     </CharString>
@@ -979,36 +988,41 @@
       
     <CharString index="88">
         
-        57 121 266 132 return
+        -167 3 3 155 -149 1 rlineto
+        -154 vlineto
+        -157 3 rlineto
+        return
       
     </CharString>
     
       
     <CharString index="89">
         
-        312 243 -83 112 return
+        311 -240 rlineto
+        -14 vlineto
+        return
       
     </CharString>
     
       
     <CharString index="90">
         
-        160 90 159 return
+        -10 126 431 152 return
       
     </CharString>
     
       
     <CharString index="91">
         
-        186 -141 -186 -176 -132 176 -188 141 return
+        125 730 124 hstem
+        return
       
     </CharString>
     
       
     <CharString index="92">
         
-        -18 126 346 125 hstem
-        53 156 209 155 vstem
+        -246 -49 callsubr
         return
       
     </CharString>
@@ -1016,14 +1030,35 @@
       
     <CharString index="93">
         
-        14 134 rlineto
-        -361 -134 hlineto
-        return
+        137 -60 56 -95 return
       
     </CharString>
     
       
     <CharString index="94">
+        
+        186 -141 -186 -176 -132 176 -188 141 return
+      
+    </CharString>
+    
+      
+    <CharString index="95">
+        
+        156 126 135 206 207 -119 124 -157 return
+      
+    </CharString>
+    
+      
+    <CharString index="96">
+        
+        99 hstem
+        348 114 vstem
+        461 return
+      
+    </CharString>
+    
+      
+    <CharString index="97">
         
         161 hstem
         return
@@ -1031,15 +1066,14 @@
     </CharString>
     
       
-    <CharString index="95">
+    <CharString index="98">
         
-        -16 129 330 -34 callsubr
-        54 156 174 158 return
+        231 151 -149 140 -50 158 -151 152 return
       
     </CharString>
     
       
-    <CharString index="96">
+    <CharString index="99">
         
         165 vstem
         return
@@ -1047,7 +1081,7 @@
     </CharString>
     
       
-    <CharString index="97">
+    <CharString index="100">
         
         -63 97 -52 -45 vvcurveto
         -39 -80 -32 -172 -45 vhcurveto
@@ -1056,32 +1090,9 @@
     </CharString>
     
       
-    <CharString index="98">
-        
-        -35 -29 29 35 35 29 29 35 return
-      
-    </CharString>
-    
-      
-    <CharString index="99">
-        
-        hintmask 1000010001010000111100010000100010101100
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="100">
-        
-        hintmask 1100010001001000111100010001010000101100
-        return
-      
-    </CharString>
-    
-      
     <CharString index="101">
         
-        70 -55 180 -4 vhcurveto
+        -177 -71 callgsubr
         return
       
     </CharString>
@@ -1089,8 +1100,7 @@
       
     <CharString index="102">
         
-        rmoveto
-        -14 callsubr
+        hintmask 1000010001001000111100010001000010011100
         return
       
     </CharString>
@@ -1098,11 +1108,7 @@
       
     <CharString index="103">
         
-        hlineto
-        hintmask 11010000
-        71 -55 rlineto
-        -14 vlineto
-        -53 -41 -2 callsubr
+        hintmask 1000010001001000111100010100000010101100
         return
       
     </CharString>
@@ -1110,64 +1116,21 @@
       
     <CharString index="104">
         
-        -18 callsubr
-        -75 -55 -34 -40 -42 vhcurveto
-        -8 62 return
+        -244 88 286 87 return
       
     </CharString>
     
       
     <CharString index="105">
         
-        183 rlineto
-        -208 hlineto
-        endchar
+        rmoveto
+        -11 callsubr
+        return
       
     </CharString>
     
       
     <CharString index="106">
-        
-        -83 5 -5 callsubr
-        24 30 30 94 37 vhcurveto
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="107">
-        
-        108 87 -90 -168 -170 -80 -87 -115 return
-      
-    </CharString>
-    
-      
-    <CharString index="108">
-        
-        545 394 4 callgsubr
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="109">
-        
-        420 -42 callsubr
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="110">
-        
-        100 83 -36 callsubr
-        hstemhm
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="111">
         
         rmoveto
         132 return
@@ -1175,9 +1138,58 @@
     </CharString>
     
       
+    <CharString index="107">
+        
+        -51 callgsubr
+        vstem
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="108">
+        
+        rmoveto
+        193 hlineto
+        4 169 rlineto
+        -193 hlineto
+        endchar
+      
+    </CharString>
+    
+      
+    <CharString index="109">
+        
+        rlineto
+        hintmask 11100000
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="110">
+        
+        284 rmoveto
+        106 hlineto
+        55 469 rlineto
+        -202 hlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="111">
+        
+        420 -38 callgsubr
+        return
+      
+    </CharString>
+    
+      
     <CharString index="112">
         
-        159 vstem
+        100 83 -33 callsubr
+        hstemhm
         return
       
     </CharString>
@@ -1185,16 +1197,28 @@
       
     <CharString index="113">
         
-        hlineto
-        16 162 rlineto
-        -106 hlineto
-        -16 -162 rlineto
+        545 394 -1 callgsubr
         return
       
     </CharString>
     
       
     <CharString index="114">
+        
+        238 159 return
+      
+    </CharString>
+    
+      
+    <CharString index="115">
+        
+        159 vstem
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="116">
         
         -54 -92 -44 -71 vvcurveto
         -44 34 -44 91 -25 vhcurveto
@@ -1203,27 +1227,11 @@
     </CharString>
     
       
-    <CharString index="115">
-        
-        45 -57 -120 -105 -52 -48 -71 hvcurveto
-        endchar
-      
-    </CharString>
-    
-      
-    <CharString index="116">
-        
-        -205 1209 hstem
-        -20 692 vstem
-        return
-      
-    </CharString>
-    
-      
     <CharString index="117">
         
-        118 328 117 76 161 hstemhm
-        return
+        419 vlineto
+        15 25 26 9 31 hhcurveto
+        endchar
       
     </CharString>
     
@@ -1237,9 +1245,26 @@
       
     <CharString index="119">
         
-        610 hstem
-        129 363 vstem
-        129 return
+        -205 1209 hstem
+        -20 692 vstem
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="120">
+        
+        -135 -205 vhcurveto
+        85 4 rmoveto
+        170 return
+      
+    </CharString>
+    
+      
+    <CharString index="121">
+        
+        118 328 117 76 161 hstemhm
+        return
       
     </CharString>
     

--- a/ligature/OperatorMonoSSmLig-Bold/subrs.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/subrs.xml
@@ -13,7 +13,7 @@
             -14 -132 231 -5 54 -20 8 -86 rlinecurve
             -227 4 -97 -93 -110 vvcurveto
             -91 67 -55 99 75 54 33 40 40 vhcurveto
-            -105 45 5 callsubr
+            -105 45 7 callsubr
             25 41 48 26 28 143 -15 hvcurveto
             1 -37 0 -32 2 -28 rrcurveto
             -19 -32 -36 -11 -30 hhcurveto
@@ -228,7 +228,7 @@
     <CharString index="15">
         
             507 hlineto
-            14 -26 callgsubr
+            14 -23 callgsubr
             -181 444 -332 hlineto
             -12 -112 185 -9 rlineto
             -323 -181 vlineto
@@ -364,7 +364,7 @@
         
             rmoveto
             164 hlineto
-            -43 callgsubr
+            -40 callgsubr
             -165 hlineto
             return
           
@@ -384,17 +384,17 @@
           
     <CharString index="27">
         
-            -9 133 168 109 163 -34 callsubr
+            -9 133 168 109 163 -31 callsubr
             79 160 175 166 vstem
             580 356 rmoveto
             273 -128 106 -373 -47 vhcurveto
-            -287 -61 -109 61 -292 -47 callgsubr
+            -287 -61 -109 61 -292 -45 callsubr
             -341 -228 rmoveto
             164 91 vlineto
             7 109 rlineto
             -98 163 hlineto
-            -30 callsubr
-            -31 callsubr
+            -27 callsubr
+            -27 callgsubr
             endchar
           
     </CharString>
@@ -445,7 +445,7 @@
           
     <CharString index="32">
         
-            -13 130 -59 callgsubr
+            -13 130 -58 callsubr
             hstem
             61 156 190 155 vstem
             return
@@ -501,8 +501,11 @@
           
     <CharString index="37">
         
-            -18 127 344 126 hstem
-            53 160 200 160 vstem
+            -88 104 -43 47 33 vvcurveto
+            44 30 18 133 -5 vhcurveto
+            -10 142 rlineto
+            -238 4 -75 -102 -102 vvcurveto
+            -43 20 -41 36 -51 vhcurveto
             return
           
     </CharString>
@@ -510,29 +513,34 @@
           
     <CharString index="38">
         
-            78 111 94 hstem
-            121 116 147 118 vstem
-            174 return
+            -18 127 344 126 hstem
+            53 160 200 160 vstem
+            return
           
     </CharString>
     
           
     <CharString index="39">
         
-            83 -112 370 298 rlineto
-            129 vlineto
-            return
+            -259 122 hstemhm
+            162 150 -150 275 hintmask 10100000
+            437 hmoveto
+            -40 59 rlineto
+            hintmask 11000000
+            -165 -70 -70 -64 -62 vvcurveto
+            -63 70 -54 180 -5 vhcurveto
+            -11 callsubr
+            -83 6 -2 callsubr
+            hintmask 10100000
+            23 30 30 95 38 vhcurveto
+            endchar
           
     </CharString>
     
           
     <CharString index="40">
         
-            rmoveto
-            182 -226 111 90 -173 219 179 210 -111 91 -181 -231 rlineto
-            272 -153 rmoveto
-            182 -226 111 90 -176 217 181 212 -111 91 -181 -231 rlineto
-            endchar
+            171 118 268 131 return
           
     </CharString>
     
@@ -547,12 +555,24 @@
           
     <CharString index="42">
         
-            0 118 328 117 return
+            42 52 43 62 44 73 -123 44 rcurveline
+            -24 -48 -24 -41 -22 -35 -23 45 -18 42 -11 40 rrcurveto
+            72 67 40 69 51 vvcurveto
+            52 -44 33 -62 -82 -86 -62 -134 -17 1 -18 3 -19 vhcurveto
+            -152 -118 -48 -108 -92 vvcurveto
+            return
           
     </CharString>
     
           
     <CharString index="43">
+        
+            0 118 328 117 return
+          
+    </CharString>
+    
+          
+    <CharString index="44">
         
             rmoveto
             111 -91 181 231 7 153 -182 226 -111 -90 176 -216 rlineto
@@ -563,7 +583,7 @@
     </CharString>
     
           
-    <CharString index="44">
+    <CharString index="45">
         
             hstem
             69 163 161 163 vstem
@@ -572,7 +592,7 @@
     </CharString>
     
           
-    <CharString index="45">
+    <CharString index="46">
         
             rmoveto
             107 -93 rlineto
@@ -586,7 +606,7 @@
     </CharString>
     
           
-    <CharString index="46">
+    <CharString index="47">
         
             0 178 -178 181 hstemhm
             50 157 221 146 hintmask 01110000
@@ -595,22 +615,11 @@
     </CharString>
     
           
-    <CharString index="47">
-        
-            95 110 78 hstem
-            121 118 148 115 vstem
-            311 return
-          
-    </CharString>
-    
-          
     <CharString index="48">
         
-            280 281 rmoveto
-            148 -291 176 20 -188 347 172 331 rlineto
-            -173 hlineto
-            -130 -272 rlineto
-            -44 272 -163 -688 163 281 hlineto
+            -45 -22 33 42 39 18 36 37 32 hvcurveto
+            28 -35 33 -40 38 -48 rrcurveto
+            -40 -27 -27 -19 -33 hhcurveto
             return
           
     </CharString>
@@ -618,26 +627,24 @@
           
     <CharString index="49">
         
-            -51 callgsubr
-            hstem
-            165 106 106 115 vstem
-            492 return
+            127 92 114 127 return
           
     </CharString>
     
           
     <CharString index="50">
         
-            0 125 438 125 return
+            -9 140 420 144 -139 139 hstemhm
+            85 171 return
           
     </CharString>
     
           
     <CharString index="51">
         
-            -141 141 hintmask 11100000
-            -52 callsubr
-            69 -53 rlineto
+            438 hlineto
+            13 135 rlineto
+            -286 553 -165 hlineto
             return
           
     </CharString>
@@ -645,7 +652,9 @@
           
     <CharString index="52">
         
-            319 443 -74 callsubr
+            553 182 135 -524 vlineto
+            -11 -135 rlineto
+            188 -553 hlineto
             return
           
     </CharString>
@@ -653,17 +662,35 @@
           
     <CharString index="53">
         
-            -36 callsubr
-            hstem
-            271 119 vstem
-            147 return
+            -141 141 hintmask 11100000
+            -49 callgsubr
+            69 -53 rlineto
+            return
           
     </CharString>
     
           
     <CharString index="54">
         
-            -28 callgsubr
+            223 113 228 -31 callsubr
+            84 161 151 8 callgsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="55">
+        
+            0 219 hstem
+            36 165 233 157 vstem
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="56">
+        
+            -25 callgsubr
             hstem
             373 119 vstem
             144 return
@@ -671,26 +698,10 @@
     </CharString>
     
           
-    <CharString index="55">
-        
-            177 693 rmoveto
-            -88 -114 return
-          
-    </CharString>
-    
-          
-    <CharString index="56">
-        
-            443 134 -20 20 hstemhm
-            80 158 156 158 hintmask 10110000
-            return
-          
-    </CharString>
-    
-          
     <CharString index="57">
         
-            125 -45 125 hstemhm
+            hmoveto
+            -44 callsubr
             return
           
     </CharString>
@@ -698,27 +709,23 @@
           
     <CharString index="58">
         
-            349 103 -192 hlineto
-            return
+            110 238 103 return
           
     </CharString>
     
           
     <CharString index="59">
         
-            -9 119 -118 128 122 91 105 130 -124 128 hstemhm
-            29 143 70 129 81 142 hintmask 01101111
-            return
+            105 hstem
+            137 364 vstem
+            181 return
           
     </CharString>
     
           
     <CharString index="60">
         
-            rmoveto
-            132 -516 -132 vlineto
-            1116 hmoveto
-            -23 callgsubr
+            349 103 -192 hlineto
             return
           
     </CharString>
@@ -726,16 +733,17 @@
           
     <CharString index="61">
         
-            rmoveto
-            250 -226 105 110 -228 195 236 195 -105 110 -248 -231 rlineto
-            endchar
+            hstem
+            232 164 vstem
+            return
           
     </CharString>
     
           
     <CharString index="62">
         
-            hintmask 1000010001001000111100010001000010101100
+            vlineto
+            356 -47 145 138 265 vvcurveto
             return
           
     </CharString>
@@ -743,7 +751,34 @@
           
     <CharString index="63">
         
-            653 -34 callsubr
+            132 -516 -38 callsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="64">
+        
+            rmoveto
+            -149 -12 rlineto
+            -998 149 vlineto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="65">
+        
+            rmoveto
+            104 -110 249 231 10 153 -251 226 -104 -110 228 -195 rlineto
+            endchar
+          
+    </CharString>
+    
+          
+    <CharString index="66">
+        
+            653 -31 callsubr
             112 400 vstem
             512 653 -73 callgsubr
             endchar
@@ -751,7 +786,7 @@
     </CharString>
     
           
-    <CharString index="64">
+    <CharString index="67">
         
             47 99 48 89 vvcurveto
             86 -83 51 -266 85 vhcurveto
@@ -762,43 +797,17 @@
     </CharString>
     
           
-    <CharString index="65">
-        
-            hlineto
-            13 -26 callgsubr
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="66">
-        
-            1061 hstemhm
-            145 152 -151 157 -58 151 -143 140 hintmask 10001000
-            494 return
-          
-    </CharString>
-    
-          
-    <CharString index="67">
-        
-            -8 141 411 155 hstem
-            69 170 vstem
-            return
-          
-    </CharString>
-    
-          
     <CharString index="68">
         
-            -4 -2 -3 -8 -9 2 -3 4 4 2 3 9 return
+            38 60 -80 71 hhcurveto
+            return
           
     </CharString>
     
           
     <CharString index="69">
         
-            hintmask 1000010001001000111100010011000010101100
+            -132 vlineto
             return
           
     </CharString>
@@ -806,7 +815,8 @@
           
     <CharString index="70">
         
-            36 67 10 188 -16 vhcurveto
+            0 137 288 137 hstem
+            74 482 vstem
             return
           
     </CharString>
@@ -814,25 +824,23 @@
           
     <CharString index="71">
         
-            101 177 95 return
+            -10 132 302 145 hstem
+            78 157 vstem
+            return
           
     </CharString>
     
           
     <CharString index="72">
         
-            rmoveto
-            -979 376 vlineto
-            15 125 rlineto
-            -240 730 232 124 hlineto
-            endchar
+            -4 -2 -3 -8 -9 2 -3 4 4 2 3 9 return
           
     </CharString>
     
           
     <CharString index="73">
         
-            134 hstem
+            475 -38 callgsubr
             return
           
     </CharString>
@@ -840,11 +848,7 @@
           
     <CharString index="74">
         
-            rlineto
-            36 49 25 64 74 vvcurveto
-            137 -89 86 -202 -27 vhcurveto
-            -687 118 vlineto
-            return
+            101 177 95 return
           
     </CharString>
     
@@ -852,17 +856,17 @@
     <CharString index="75">
         
             rmoveto
-            191 hlineto
-            4 167 rlineto
-            -190 hlineto
-            return
+            -226 hlineto
+            -11 -125 rlineto
+            388 979 -381 -124 230 hlineto
+            endchar
           
     </CharString>
     
           
     <CharString index="76">
         
-            -165 -31 -62 -144 20 vhcurveto
+            134 hstem
             return
           
     </CharString>
@@ -870,13 +874,46 @@
           
     <CharString index="77">
         
-            141 14 34 -83 -160 vvcurveto
+            rmoveto
+            -81 25 -65 -58 -39 -103 -1 -92 rlinecurve
+            184 8 -19 68 2 85 19 67 rlinecurve
             return
           
     </CharString>
     
           
     <CharString index="78">
+        
+            5 callgsubr
+            271 119 return
+          
+    </CharString>
+    
+          
+    <CharString index="79">
+        
+            0 135 hstem
+            111 165 return
+          
+    </CharString>
+    
+          
+    <CharString index="80">
+        
+            141 14 34 -83 -160 vvcurveto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="81">
+        
+            157 157 return
+          
+    </CharString>
+    
+          
+    <CharString index="82">
         
             rmoveto
             8 -107 rlineto
@@ -885,14 +922,7 @@
     </CharString>
     
           
-    <CharString index="79">
-        
-            157 157 return
-          
-    </CharString>
-    
-          
-    <CharString index="80">
+    <CharString index="83">
         
             -59 -175 rlineto
             -3 hlineto
@@ -903,7 +933,7 @@
     </CharString>
     
           
-    <CharString index="81">
+    <CharString index="84">
         
             -1 87 -108 43 41 vvcurveto
             27 36 13 115 14 vhcurveto
@@ -913,51 +943,27 @@
     </CharString>
     
           
-    <CharString index="82">
-        
-            145 hlineto
-            7 194 rlineto
-            -146 hlineto
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="83">
-        
-            -112 124 return
-          
-    </CharString>
-    
-          
-    <CharString index="84">
-        
-            -167 3 3 155 -149 1 rlineto
-            -154 vlineto
-            -157 3 rlineto
-            return
-          
-    </CharString>
-    
-          
     <CharString index="85">
         
-            -10 126 431 152 return
+            17 26 28 10 32 hhcurveto
+            return
           
     </CharString>
     
           
     <CharString index="86">
         
-            -18 133 458 133 return
+            -94 -59 -52 -65 -93 vvcurveto
+            -96 59 -72 121 69 68 31 68 52 vhcurveto
+            return
           
     </CharString>
     
           
     <CharString index="87">
         
-            311 -240 rlineto
-            -14 vlineto
+            -44 callsubr
+            1116 -50 callsubr
             return
           
     </CharString>
@@ -965,20 +971,49 @@
           
     <CharString index="88">
         
-            125 730 124 hstem
-            return
+            57 121 266 132 return
           
     </CharString>
     
           
     <CharString index="89">
         
-            137 -60 56 -95 return
+            72 147 188 147 return
           
     </CharString>
     
           
     <CharString index="90">
+        
+            312 243 -83 112 return
+          
+    </CharString>
+    
+          
+    <CharString index="91">
+        
+            -18 133 458 133 return
+          
+    </CharString>
+    
+          
+    <CharString index="92">
+        
+            160 90 159 return
+          
+    </CharString>
+    
+          
+    <CharString index="93">
+        
+            -18 126 346 125 hstem
+            53 156 209 155 vstem
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="94">
         
             -18 132 460 132 hstem
             46 165 202 166 vstem
@@ -987,23 +1022,16 @@
     </CharString>
     
           
-    <CharString index="91">
+    <CharString index="95">
         
-            156 126 135 206 207 -119 124 -157 return
+            14 134 rlineto
+            -361 -134 hlineto
+            return
           
     </CharString>
     
           
-    <CharString index="92">
-        
-            99 hstem
-            348 114 vstem
-            461 return
-          
-    </CharString>
-    
-          
-    <CharString index="93">
+    <CharString index="96">
         
             13 122 rlineto
             return
@@ -1011,7 +1039,15 @@
     </CharString>
     
           
-    <CharString index="94">
+    <CharString index="97">
+        
+            -16 129 330 -31 callsubr
+            54 156 174 158 return
+          
+    </CharString>
+    
+          
+    <CharString index="98">
         
             rmoveto
             46 -147 rlineto
@@ -1022,14 +1058,7 @@
     </CharString>
     
           
-    <CharString index="95">
-        
-            231 151 -149 140 -50 158 -151 152 return
-          
-    </CharString>
-    
-          
-    <CharString index="96">
+    <CharString index="99">
         
             4 2 2 4 1 hvcurveto
             5 hlineto
@@ -1039,47 +1068,23 @@
     </CharString>
     
           
-    <CharString index="97">
+    <CharString index="100">
         
             -9 -7 -7 -9 -9 -7 6 10 return
           
     </CharString>
     
           
-    <CharString index="98">
-        
-            -177 -71 callgsubr
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="99">
-        
-            hintmask 1000010001001000111100010100000010101100
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="100">
-        
-            hintmask 1000010001001000111100010001000010011100
-            return
-          
-    </CharString>
-    
-          
     <CharString index="101">
         
-            -244 88 286 87 return
+            -35 -29 29 35 35 29 29 35 return
           
     </CharString>
     
           
     <CharString index="102">
         
-            -30 17 23 vvcurveto
+            hintmask 1100010001001000111100010001010000101100
             return
           
     </CharString>
@@ -1087,8 +1092,7 @@
           
     <CharString index="103">
         
-            -54 callgsubr
-            vstem
+            hintmask 1000010001010000111100010000100010101100
             return
           
     </CharString>
@@ -1096,19 +1100,15 @@
           
     <CharString index="104">
         
-            rmoveto
-            193 hlineto
-            4 169 rlineto
-            -193 hlineto
-            endchar
+            70 -55 180 -4 vhcurveto
+            return
           
     </CharString>
     
           
     <CharString index="105">
         
-            rlineto
-            hintmask 11100000
+            -30 17 23 vvcurveto
             return
           
     </CharString>
@@ -1116,10 +1116,11 @@
           
     <CharString index="106">
         
-            284 rmoveto
-            106 hlineto
-            55 469 rlineto
-            -202 hlineto
+            hlineto
+            hintmask 11010000
+            71 -55 rlineto
+            -14 vlineto
+            -53 -41 2 callgsubr
             return
           
     </CharString>
@@ -1127,53 +1128,56 @@
           
     <CharString index="107">
         
-            rmoveto
-            -49 callsubr
-            return
+            -14 callgsubr
+            -75 -55 -34 -40 -42 vhcurveto
+            -8 62 return
           
     </CharString>
     
           
     <CharString index="108">
         
-            -312 -243 83 -112 return
+            183 rlineto
+            -208 hlineto
+            endchar
           
     </CharString>
     
           
     <CharString index="109">
         
-            -8 129 322 119 return
+            108 87 -90 -168 -170 -80 -87 -115 return
           
     </CharString>
     
           
     <CharString index="110">
         
-            238 159 return
+            -83 5 -2 callsubr
+            24 30 30 94 37 vhcurveto
+            return
           
     </CharString>
     
           
     <CharString index="111">
         
-            175 hlineto
-            return
+            -312 -243 83 -112 return
           
     </CharString>
     
           
     <CharString index="112">
         
-            rmoveto
-            -46 -28 return
+            -8 129 322 119 return
           
     </CharString>
     
           
     <CharString index="113">
         
-            141 472 0 callsubr
+            rmoveto
+            -47 callsubr
             return
           
     </CharString>
@@ -1181,22 +1185,49 @@
           
     <CharString index="114">
         
-            419 vlineto
-            15 25 26 9 31 hhcurveto
-            endchar
+            rmoveto
+            -46 -28 return
           
     </CharString>
     
           
     <CharString index="115">
         
-            -242 4 callgsubr
+            141 472 6 callsubr
             return
           
     </CharString>
     
           
     <CharString index="116">
+        
+            hlineto
+            16 162 rlineto
+            -106 hlineto
+            -16 -162 rlineto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="117">
+        
+            45 -57 -120 -105 -52 -48 -71 hvcurveto
+            endchar
+          
+    </CharString>
+    
+          
+    <CharString index="118">
+        
+            610 hstem
+            129 363 vstem
+            129 return
+          
+    </CharString>
+    
+          
+    <CharString index="119">
         
             1049 hstem
             110 156 vstem
@@ -1205,16 +1236,7 @@
     </CharString>
     
           
-    <CharString index="117">
-        
-            -135 -205 vhcurveto
-            85 4 rmoveto
-            170 return
-          
-    </CharString>
-    
-          
-    <CharString index="118">
+    <CharString index="120">
         
             610 hstem
             134 363 vstem

--- a/ligature/OperatorMonoSSmLig-BoldItalic/config.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/config.xml
@@ -102,7 +102,7 @@
         <metricDataFormat value="0"/>
         
     
-        <numberOfHMetrics value="477"/>
+        <numberOfHMetrics value="478"/>
         
   
     </hhea>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/config.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/config.xml
@@ -23,7 +23,7 @@
     
     
     
-        <xMin value="-449"/>
+        <xMin value="-1787"/>
         
     
         <yMin value="-395"/>
@@ -69,7 +69,7 @@
         <advanceWidthMax value="625"/>
         
     
-        <minLeftSideBearing value="-449"/>
+        <minLeftSideBearing value="-1787"/>
         
     
         <minRightSideBearing value="-238"/>
@@ -102,13 +102,13 @@
         <metricDataFormat value="0"/>
         
     
-        <numberOfHMetrics value="449"/>
+        <numberOfHMetrics value="477"/>
         
   
     </hhea>
     <CFF>
         <CFFFont>
-            <FontBBox value="-449 -395 863 1271"/>
+            <FontBBox value="-1787 -395 863 1271"/>
         </CFFFont>
     </CFF>
     <CFF>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/ampersand_ampersand.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/ampersand_ampersand.liga.xml
@@ -1,0 +1,52 @@
+<Glyph name="ampersand_ampersand.liga" lsb="-513" width="625">
+    <CharString>
+        -10 137 hstem
+        -513 149 381 149 vstem
+        -513 142 rmoveto
+        {efa8f865} callgsubr
+        140 -156 296 46 94 110 25 -37 27 -36 30 -37 131 90 rcurveline
+        -40 48 -34 45 -30 44 {4fde3afe} callsubr
+        -1 vlineto
+        -25 26 -21 23 -10 14 {4fde3afe} callsubr
+        149 39 rmoveto
+        {18c1be37} callgsubr
+        530 hmoveto
+        {18c1be37} callgsubr
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="4fde3afe">
+            42 52 43 62 44 73 -123 44 rcurveline
+            -24 -48 -24 -41 -22 -35 -23 45 -18 42 -11 40 rrcurveto
+            72 67 40 69 51 vvcurveto
+            52 -44 33 -62 -82 -86 -62 -134 -17 1 -18 3 -19 vhcurveto
+            -152 -118 -48 -108 -92 vvcurveto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="4fde3afe">
+            42 52 43 62 44 73 -123 44 rcurveline
+            -24 -48 -24 -41 -22 -35 -23 45 -18 42 -11 40 rrcurveto
+            72 67 40 69 51 vvcurveto
+            52 -44 33 -62 -82 -86 -62 -134 -17 1 -18 3 -19 vhcurveto
+            -152 -118 -48 -108 -92 vvcurveto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="efa8f865">
+            -91 50 -61 97 69 73 31 66 76 vhcurveto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="18c1be37">
+            40 24 53 60 60 vhcurveto
+            {976989be} callgsubr
+            -29 -17 16 38 hvcurveto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="976989be">
+            18 -48 24 -51 30 -53 rrcurveto
+            -40 -44 -38 -15 -28 hhcurveto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/ampersand_ampersand.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/ampersand_ampersand.liga.xml
@@ -9,9 +9,9 @@
         -1 vlineto
         -25 26 -21 23 -10 14 {4fde3afe} callsubr
         149 39 rmoveto
-        {18c1be37} callgsubr
+        {52700f2f} callsubr
         530 hmoveto
-        {18c1be37} callgsubr
+        {52700f2f} callsubr
         endchar
     </CharString>
     <Subrs>
@@ -31,21 +31,21 @@
             -152 -118 -48 -108 -92 vvcurveto
             return
         </CharString>
+        <CharString index="2" fingerprint="52700f2f">
+            40 24 53 60 60 vhcurveto
+            {976989be} callsubr
+            -29 -17 16 38 hvcurveto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="976989be">
+            18 -48 24 -51 30 -53 rrcurveto
+            -40 -44 -38 -15 -28 hhcurveto
+            return
+        </CharString>
     </Subrs>
     <GlobalSubrs>
         <CharString index="0" fingerprint="efa8f865">
             -91 50 -61 97 69 73 31 66 76 vhcurveto
-            return
-        </CharString>
-        <CharString index="1" fingerprint="18c1be37">
-            40 24 53 60 60 vhcurveto
-            {976989be} callgsubr
-            -29 -17 16 38 hvcurveto
-            return
-        </CharString>
-        <CharString index="2" fingerprint="976989be">
-            18 -48 24 -51 30 -53 rrcurveto
-            -40 -44 -38 -15 -28 hhcurveto
             return
         </CharString>
     </GlobalSubrs>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/bar_bar.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/bar_bar.liga.xml
@@ -1,0 +1,23 @@
+<Glyph name="bar_bar.liga" lsb="-402" width="625">
+    <CharString>
+        -402 342 125 342 vstem
+        -60 798 {3e5ef760} callsubr
+        662 1001 {3e5ef760} callsubr
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="3e5ef760">
+            rmoveto
+            -148 -3 -194 -998 rlineto
+            147 hlineto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="3e5ef760">
+            rmoveto
+            -148 -3 -194 -998 rlineto
+            147 hlineto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs/>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/bar_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/bar_greater.liga.xml
@@ -1,0 +1,23 @@
+<Glyph name="bar_greater.liga" lsb="-356" width="625">
+    <CharString>
+        -356 755 vstem
+        -14 798 {3e5ef760} callsubr
+        584 439 {d4f80b1e} callsubr
+        -417 -314 122 626 297 -299 rlineto
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="3e5ef760">
+            rmoveto
+            -148 -3 -194 -998 rlineto
+            147 hlineto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="d4f80b1e">
+            24 130 rlineto
+            -152 -57 rmoveto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs/>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/bar_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/bar_greater.liga.xml
@@ -2,7 +2,7 @@
     <CharString>
         -356 755 vstem
         -14 798 {3e5ef760} callsubr
-        584 439 {d4f80b1e} callsubr
+        584 439 {d4f80b1e} callgsubr
         -417 -314 122 626 297 -299 rlineto
         endchar
     </CharString>
@@ -13,11 +13,12 @@
             147 hlineto
             return
         </CharString>
-        <CharString index="1" fingerprint="d4f80b1e">
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="d4f80b1e">
             24 130 rlineto
             -152 -57 rmoveto
             return
         </CharString>
-    </Subrs>
-    <GlobalSubrs/>
+    </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/colon_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/colon_equal.liga.xml
@@ -1,0 +1,43 @@
+<Glyph name="colon_equal.liga" lsb="-391" width="625">
+    <CharString>
+        124 186 57 187 hstem
+        -211 809 vstem
+        -308 557 rmoveto
+        -39 -187 189 -3 39 187 rlineto
+        65 -28 rmoveto
+        -27 -131 rlineto
+        473 {256033b9} callsubr
+        -809 -399 rmoveto
+        189 -3 39 187 -189 3 rlineto
+        223 -162 rmoveto
+        473 {800351b2} callsubr
+        -473 hlineto
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="256033b9">
+            hlineto
+            {d5a87c62} callsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="fb64a85a">
+            131 rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="800351b2">
+            hlineto
+            {b0652e66} callgsubr
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="b0652e66">
+            27 132 rlineto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal.2.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal.2.liga.xml
@@ -1,11 +1,11 @@
 <Glyph name="equal_equal.2.liga" lsb="-498" width="625">
     <CharString>
-        {d60c0b36} callgsubr
+        {d60c0b36} callsubr
         -498 547 2 547 vstem
-        32 {ea169de2} callsubr
+        32 {e17922fa} callsubr
         -481 {fdbdf28a} callsubr
         1022 hmoveto
-        {d5a87c62} callgsubr
+        {d5a87c62} callsubr
         -481 {fdbdf28a} callsubr
         -106 {2386b079} callgsubr
         -482 {ebe0bd64} callsubr
@@ -15,53 +15,53 @@
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="1deed8a2">
+        <CharString index="0" fingerprint="d60c0b36">
+            {1deed8a2} callsubr
+            hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="1deed8a2">
             152 {145d2e17} callgsubr
             return
         </CharString>
-        <CharString index="1" fingerprint="ea169de2">
-            395 {2b0429de} callsubr
+        <CharString index="2" fingerprint="e17922fa">
+            395 {0d1be3e3} callgsubr
             return
         </CharString>
-        <CharString index="2" fingerprint="2b0429de">
-            rmoveto
-            {d5a87c62} callgsubr
+        <CharString index="3" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
             return
         </CharString>
-        <CharString index="3" fingerprint="fb64a85a">
+        <CharString index="4" fingerprint="fb64a85a">
             131 rlineto
             return
         </CharString>
-        <CharString index="4" fingerprint="fdbdf28a">
+        <CharString index="5" fingerprint="fdbdf28a">
             hlineto
             -27 -131 rlineto
             return
         </CharString>
-        <CharString index="5" fingerprint="ebe0bd64">
+        <CharString index="6" fingerprint="ebe0bd64">
             hlineto
             -27 -132 rlineto
             return
         </CharString>
     </Subrs>
     <GlobalSubrs>
-        <CharString index="0" fingerprint="d60c0b36">
-            {1deed8a2} callsubr
-            hstem
-            return
-        </CharString>
-        <CharString index="1" fingerprint="145d2e17">
+        <CharString index="0" fingerprint="145d2e17">
             132 111 131 return
         </CharString>
-        <CharString index="2" fingerprint="d5a87c62">
-            26 {fb64a85a} callsubr
+        <CharString index="1" fingerprint="0d1be3e3">
+            rmoveto
+            {d5a87c62} callsubr
             return
         </CharString>
-        <CharString index="3" fingerprint="2386b079">
+        <CharString index="2" fingerprint="2386b079">
             -243 rmoveto
             {b0652e66} callgsubr
             return
         </CharString>
-        <CharString index="4" fingerprint="b0652e66">
+        <CharString index="3" fingerprint="b0652e66">
             27 132 rlineto
             return
         </CharString>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal.2.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal.2.liga.xml
@@ -1,0 +1,69 @@
+<Glyph name="equal_equal.2.liga" lsb="-498" width="625">
+    <CharString>
+        {d60c0b36} callgsubr
+        -498 547 2 547 vstem
+        32 {ea169de2} callsubr
+        -481 {fdbdf28a} callsubr
+        1022 hmoveto
+        {d5a87c62} callgsubr
+        -481 {fdbdf28a} callsubr
+        -106 {2386b079} callgsubr
+        -482 {ebe0bd64} callsubr
+        1022 hmoveto
+        {b0652e66} callgsubr
+        -482 {ebe0bd64} callsubr
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="1deed8a2">
+            152 {145d2e17} callgsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="ea169de2">
+            395 {2b0429de} callsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="2b0429de">
+            rmoveto
+            {d5a87c62} callgsubr
+            return
+        </CharString>
+        <CharString index="3" fingerprint="fb64a85a">
+            131 rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="fdbdf28a">
+            hlineto
+            -27 -131 rlineto
+            return
+        </CharString>
+        <CharString index="5" fingerprint="ebe0bd64">
+            hlineto
+            -27 -132 rlineto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="d60c0b36">
+            {1deed8a2} callsubr
+            hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="2" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
+            return
+        </CharString>
+        <CharString index="3" fingerprint="2386b079">
+            -243 rmoveto
+            {b0652e66} callgsubr
+            return
+        </CharString>
+        <CharString index="4" fingerprint="b0652e66">
+            27 132 rlineto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal.liga.xml
@@ -1,61 +1,61 @@
 <Glyph name="equal_equal.liga" lsb="-574" width="625">
     <CharString>
-        {d60c0b36} callgsubr
+        {d60c0b36} callsubr
         -574 1172 vstem
-        572 {ea169de2} callsubr
+        572 {e17922fa} callsubr
         -1097 {fdbdf28a} callsubr
         1050 {2386b079} callgsubr
         -1098 {ebe0bd64} callsubr
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="1deed8a2">
+        <CharString index="0" fingerprint="d60c0b36">
+            {1deed8a2} callsubr
+            hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="1deed8a2">
             152 {145d2e17} callgsubr
             return
         </CharString>
-        <CharString index="1" fingerprint="ea169de2">
-            395 {2b0429de} callsubr
+        <CharString index="2" fingerprint="e17922fa">
+            395 {0d1be3e3} callgsubr
             return
         </CharString>
-        <CharString index="2" fingerprint="2b0429de">
-            rmoveto
-            {d5a87c62} callgsubr
+        <CharString index="3" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
             return
         </CharString>
-        <CharString index="3" fingerprint="fb64a85a">
+        <CharString index="4" fingerprint="fb64a85a">
             131 rlineto
             return
         </CharString>
-        <CharString index="4" fingerprint="fdbdf28a">
+        <CharString index="5" fingerprint="fdbdf28a">
             hlineto
             -27 -131 rlineto
             return
         </CharString>
-        <CharString index="5" fingerprint="ebe0bd64">
+        <CharString index="6" fingerprint="ebe0bd64">
             hlineto
             -27 -132 rlineto
             return
         </CharString>
     </Subrs>
     <GlobalSubrs>
-        <CharString index="0" fingerprint="d60c0b36">
-            {1deed8a2} callsubr
-            hstem
-            return
-        </CharString>
-        <CharString index="1" fingerprint="145d2e17">
+        <CharString index="0" fingerprint="145d2e17">
             132 111 131 return
         </CharString>
-        <CharString index="2" fingerprint="d5a87c62">
-            26 {fb64a85a} callsubr
+        <CharString index="1" fingerprint="0d1be3e3">
+            rmoveto
+            {d5a87c62} callsubr
             return
         </CharString>
-        <CharString index="3" fingerprint="2386b079">
+        <CharString index="2" fingerprint="2386b079">
             -243 rmoveto
             {b0652e66} callgsubr
             return
         </CharString>
-        <CharString index="4" fingerprint="b0652e66">
+        <CharString index="3" fingerprint="b0652e66">
             27 132 rlineto
             return
         </CharString>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal.liga.xml
@@ -1,0 +1,63 @@
+<Glyph name="equal_equal.liga" lsb="-574" width="625">
+    <CharString>
+        {d60c0b36} callgsubr
+        -574 1172 vstem
+        572 {ea169de2} callsubr
+        -1097 {fdbdf28a} callsubr
+        1050 {2386b079} callgsubr
+        -1098 {ebe0bd64} callsubr
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="1deed8a2">
+            152 {145d2e17} callgsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="ea169de2">
+            395 {2b0429de} callsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="2b0429de">
+            rmoveto
+            {d5a87c62} callgsubr
+            return
+        </CharString>
+        <CharString index="3" fingerprint="fb64a85a">
+            131 rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="fdbdf28a">
+            hlineto
+            -27 -131 rlineto
+            return
+        </CharString>
+        <CharString index="5" fingerprint="ebe0bd64">
+            hlineto
+            -27 -132 rlineto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="d60c0b36">
+            {1deed8a2} callsubr
+            hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="2" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
+            return
+        </CharString>
+        <CharString index="3" fingerprint="2386b079">
+            -243 rmoveto
+            {b0652e66} callgsubr
+            return
+        </CharString>
+        <CharString index="4" fingerprint="b0652e66">
+            27 132 rlineto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal_equal.2.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal_equal.2.liga.xml
@@ -1,0 +1,67 @@
+<Glyph name="equal_equal_equal.2.liga" lsb="-1199" width="625">
+    <CharString>
+        {d60c0b36} callgsubr
+        -1199 1797 vstem
+        -632 395 rmoveto
+        {821ef088} callsubr
+        1121 hmoveto
+        {821ef088} callsubr
+        1121 hmoveto
+        {821ef088} callsubr
+        -733 -243 rmoveto
+        {a4cb57ae} callsubr
+        1121 hmoveto
+        {a4cb57ae} callsubr
+        1121 hmoveto
+        {a4cb57ae} callsubr
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="1deed8a2">
+            152 {145d2e17} callgsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="821ef088">
+            {d5a87c62} callgsubr
+            -518 {fdbdf28a} callsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="fb64a85a">
+            131 rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="fdbdf28a">
+            hlineto
+            -27 -131 rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="a4cb57ae">
+            {b0652e66} callgsubr
+            -519 {ebe0bd64} callsubr
+            return
+        </CharString>
+        <CharString index="5" fingerprint="ebe0bd64">
+            hlineto
+            -27 -132 rlineto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="d60c0b36">
+            {1deed8a2} callsubr
+            hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="2" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
+            return
+        </CharString>
+        <CharString index="3" fingerprint="b0652e66">
+            27 132 rlineto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal_equal.2.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal_equal.2.liga.xml
@@ -1,43 +1,42 @@
 <Glyph name="equal_equal_equal.2.liga" lsb="-1199" width="625">
     <CharString>
-        {d60c0b36} callgsubr
+        {d60c0b36} callsubr
         -1199 1797 vstem
         -632 395 rmoveto
-        {821ef088} callsubr
+        {848e4ae3} callgsubr
         1121 hmoveto
-        {821ef088} callsubr
+        {848e4ae3} callgsubr
         1121 hmoveto
-        {821ef088} callsubr
+        {848e4ae3} callgsubr
         -733 -243 rmoveto
-        {a4cb57ae} callsubr
+        {a4cb57ae} callgsubr
         1121 hmoveto
-        {a4cb57ae} callsubr
+        {a4cb57ae} callgsubr
         1121 hmoveto
-        {a4cb57ae} callsubr
+        {a4cb57ae} callgsubr
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="1deed8a2">
+        <CharString index="0" fingerprint="d60c0b36">
+            {1deed8a2} callsubr
+            hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="1deed8a2">
             152 {145d2e17} callgsubr
             return
         </CharString>
-        <CharString index="1" fingerprint="821ef088">
-            {d5a87c62} callgsubr
-            -518 {fdbdf28a} callsubr
+        <CharString index="2" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
             return
         </CharString>
-        <CharString index="2" fingerprint="fb64a85a">
+        <CharString index="3" fingerprint="fb64a85a">
             131 rlineto
             return
         </CharString>
-        <CharString index="3" fingerprint="fdbdf28a">
+        <CharString index="4" fingerprint="fdbdf28a">
             hlineto
             -27 -131 rlineto
-            return
-        </CharString>
-        <CharString index="4" fingerprint="a4cb57ae">
-            {b0652e66} callgsubr
-            -519 {ebe0bd64} callsubr
             return
         </CharString>
         <CharString index="5" fingerprint="ebe0bd64">
@@ -47,16 +46,17 @@
         </CharString>
     </Subrs>
     <GlobalSubrs>
-        <CharString index="0" fingerprint="d60c0b36">
-            {1deed8a2} callsubr
-            hstem
-            return
-        </CharString>
-        <CharString index="1" fingerprint="145d2e17">
+        <CharString index="0" fingerprint="145d2e17">
             132 111 131 return
         </CharString>
-        <CharString index="2" fingerprint="d5a87c62">
-            26 {fb64a85a} callsubr
+        <CharString index="1" fingerprint="848e4ae3">
+            {d5a87c62} callsubr
+            -518 {fdbdf28a} callsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="a4cb57ae">
+            {b0652e66} callgsubr
+            -519 {ebe0bd64} callsubr
             return
         </CharString>
         <CharString index="3" fingerprint="b0652e66">

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal_equal.liga.xml
@@ -5,19 +5,34 @@
         -1223 1845 cntrmask 11100000
         -1100 648 rmoveto
         -27 -131 rlineto
-        1723 {4ff4d421} callsubr
-        -1797 -374 {f7cec177} callgsubr
-        -75 -375 {f7cec177} callgsubr
+        1723 {256033b9} callsubr
+        -1797 -374 {1e39ac37} callsubr
+        -75 -375 {1e39ac37} callsubr
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="4ff4d421">
+        <CharString index="0" fingerprint="256033b9">
             hlineto
-            {d5a87c62} callgsubr
+            {d5a87c62} callsubr
             return
         </CharString>
-        <CharString index="1" fingerprint="fb64a85a">
+        <CharString index="1" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="fb64a85a">
             131 rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="1e39ac37">
+            rmoveto
+            1723 {800351b2} callsubr
+            -1723 hlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="800351b2">
+            hlineto
+            {b0652e66} callgsubr
             return
         </CharString>
     </Subrs>
@@ -25,22 +40,7 @@
         <CharString index="0" fingerprint="145d2e17">
             132 111 131 return
         </CharString>
-        <CharString index="1" fingerprint="d5a87c62">
-            26 {fb64a85a} callsubr
-            return
-        </CharString>
-        <CharString index="2" fingerprint="f7cec177">
-            rmoveto
-            1723 {800351b2} callgsubr
-            -1723 hlineto
-            return
-        </CharString>
-        <CharString index="3" fingerprint="800351b2">
-            hlineto
-            {b0652e66} callgsubr
-            return
-        </CharString>
-        <CharString index="4" fingerprint="b0652e66">
+        <CharString index="1" fingerprint="b0652e66">
             27 132 rlineto
             return
         </CharString>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal_equal.liga.xml
@@ -1,0 +1,48 @@
+<Glyph name="equal_equal_equal.liga" lsb="-1223" width="625">
+    <CharString>
+        31 {145d2e17} callgsubr
+        112 131 hstem
+        -1223 1845 cntrmask 11100000
+        -1100 648 rmoveto
+        -27 -131 rlineto
+        1723 {4ff4d421} callsubr
+        -1797 -374 {f7cec177} callgsubr
+        -75 -375 {f7cec177} callgsubr
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="4ff4d421">
+            hlineto
+            {d5a87c62} callgsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="fb64a85a">
+            131 rlineto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="1" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="f7cec177">
+            rmoveto
+            1723 {800351b2} callgsubr
+            -1723 hlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="800351b2">
+            hlineto
+            {b0652e66} callgsubr
+            return
+        </CharString>
+        <CharString index="4" fingerprint="b0652e66">
+            27 132 rlineto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal_greater.liga.xml
@@ -1,0 +1,68 @@
+<Glyph name="equal_equal_greater.liga" lsb="-1199" width="625">
+    <CharString>
+        {d60c0b36} callgsubr
+        -1199 1758 {cf96d680} callgsubr
+        -1327 {fdbdf28a} callsubr
+        1486 {094a6dd1} callsubr
+        -1539 {ebe0bd64} callsubr
+        1355 hlineto
+        -93 -58 {2e3e492a} callsubr
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="1deed8a2">
+            152 {145d2e17} callgsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="ed114548">
+            246 693 rmoveto
+            -107 -104 return
+        </CharString>
+        <CharString index="2" fingerprint="fdbdf28a">
+            hlineto
+            -27 -131 rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="094a6dd1">
+            hlineto
+            74 -73 -2 -13 -40 -25 rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="ebe0bd64">
+            hlineto
+            -27 -132 rlineto
+            return
+        </CharString>
+        <CharString index="5" fingerprint="2e3e492a">
+            {0294fbed} callsubr
+            endchar
+        </CharString>
+        <CharString index="6" fingerprint="0294fbed">
+            {ce9611a3} callgsubr
+            rlineto
+            return
+        </CharString>
+        <CharString index="7" fingerprint="9ffb92b0">
+            63 -122 409 264 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="d60c0b36">
+            {1deed8a2} callsubr
+            hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="2" fingerprint="cf96d680">
+            vstem
+            {ed114548} callsubr
+            64 -63 rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="ce9611a3">
+            {9ffb92b0} callsubr
+            24 130 return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_equal_greater.liga.xml
@@ -1,30 +1,30 @@
 <Glyph name="equal_equal_greater.liga" lsb="-1199" width="625">
     <CharString>
-        {d60c0b36} callgsubr
+        {d60c0b36} callsubr
         -1199 1758 {cf96d680} callgsubr
         -1327 {fdbdf28a} callsubr
-        1486 {094a6dd1} callsubr
+        1486 {094a6dd1} callgsubr
         -1539 {ebe0bd64} callsubr
         1355 hlineto
-        -93 -58 {2e3e492a} callsubr
+        -93 -58 {9d6990a4} callsubr
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="1deed8a2">
+        <CharString index="0" fingerprint="d60c0b36">
+            {1deed8a2} callsubr
+            hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="1deed8a2">
             152 {145d2e17} callgsubr
             return
         </CharString>
-        <CharString index="1" fingerprint="ed114548">
+        <CharString index="2" fingerprint="ed114548">
             246 693 rmoveto
             -107 -104 return
         </CharString>
-        <CharString index="2" fingerprint="fdbdf28a">
+        <CharString index="3" fingerprint="fdbdf28a">
             hlineto
             -27 -131 rlineto
-            return
-        </CharString>
-        <CharString index="3" fingerprint="094a6dd1">
-            hlineto
-            74 -73 -2 -13 -40 -25 rlineto
             return
         </CharString>
         <CharString index="4" fingerprint="ebe0bd64">
@@ -32,37 +32,37 @@
             -27 -132 rlineto
             return
         </CharString>
-        <CharString index="5" fingerprint="2e3e492a">
-            {0294fbed} callsubr
+        <CharString index="5" fingerprint="9d6990a4">
+            {0a376d15} callsubr
             endchar
         </CharString>
-        <CharString index="6" fingerprint="0294fbed">
-            {ce9611a3} callgsubr
+        <CharString index="6" fingerprint="0a376d15">
+            {ce9611a3} callsubr
             rlineto
             return
         </CharString>
-        <CharString index="7" fingerprint="9ffb92b0">
+        <CharString index="7" fingerprint="ce9611a3">
+            {9ffb92b0} callsubr
+            24 130 return
+        </CharString>
+        <CharString index="8" fingerprint="9ffb92b0">
             63 -122 409 264 return
         </CharString>
     </Subrs>
     <GlobalSubrs>
-        <CharString index="0" fingerprint="d60c0b36">
-            {1deed8a2} callsubr
-            hstem
-            return
-        </CharString>
-        <CharString index="1" fingerprint="145d2e17">
+        <CharString index="0" fingerprint="145d2e17">
             132 111 131 return
         </CharString>
-        <CharString index="2" fingerprint="cf96d680">
+        <CharString index="1" fingerprint="cf96d680">
             vstem
             {ed114548} callsubr
             64 -63 rlineto
             return
         </CharString>
-        <CharString index="3" fingerprint="ce9611a3">
-            {9ffb92b0} callsubr
-            24 130 return
+        <CharString index="2" fingerprint="094a6dd1">
+            hlineto
+            74 -73 -2 -13 -40 -25 rlineto
+            return
         </CharString>
     </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_greater.liga.xml
@@ -1,0 +1,68 @@
+<Glyph name="equal_greater.liga" lsb="-574" width="625">
+    <CharString>
+        {d60c0b36} callgsubr
+        -574 1133 {cf96d680} callgsubr
+        -702 {fdbdf28a} callsubr
+        861 {094a6dd1} callsubr
+        -914 {ebe0bd64} callsubr
+        730 hlineto
+        -93 -58 {2e3e492a} callsubr
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="1deed8a2">
+            152 {145d2e17} callgsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="ed114548">
+            246 693 rmoveto
+            -107 -104 return
+        </CharString>
+        <CharString index="2" fingerprint="fdbdf28a">
+            hlineto
+            -27 -131 rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="094a6dd1">
+            hlineto
+            74 -73 -2 -13 -40 -25 rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="ebe0bd64">
+            hlineto
+            -27 -132 rlineto
+            return
+        </CharString>
+        <CharString index="5" fingerprint="2e3e492a">
+            {0294fbed} callsubr
+            endchar
+        </CharString>
+        <CharString index="6" fingerprint="0294fbed">
+            {ce9611a3} callgsubr
+            rlineto
+            return
+        </CharString>
+        <CharString index="7" fingerprint="9ffb92b0">
+            63 -122 409 264 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="d60c0b36">
+            {1deed8a2} callsubr
+            hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="2" fingerprint="cf96d680">
+            vstem
+            {ed114548} callsubr
+            64 -63 rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="ce9611a3">
+            {9ffb92b0} callsubr
+            24 130 return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_greater.liga.xml
@@ -1,30 +1,30 @@
 <Glyph name="equal_greater.liga" lsb="-574" width="625">
     <CharString>
-        {d60c0b36} callgsubr
+        {d60c0b36} callsubr
         -574 1133 {cf96d680} callgsubr
         -702 {fdbdf28a} callsubr
-        861 {094a6dd1} callsubr
+        861 {094a6dd1} callgsubr
         -914 {ebe0bd64} callsubr
         730 hlineto
-        -93 -58 {2e3e492a} callsubr
+        -93 -58 {9d6990a4} callsubr
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="1deed8a2">
+        <CharString index="0" fingerprint="d60c0b36">
+            {1deed8a2} callsubr
+            hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="1deed8a2">
             152 {145d2e17} callgsubr
             return
         </CharString>
-        <CharString index="1" fingerprint="ed114548">
+        <CharString index="2" fingerprint="ed114548">
             246 693 rmoveto
             -107 -104 return
         </CharString>
-        <CharString index="2" fingerprint="fdbdf28a">
+        <CharString index="3" fingerprint="fdbdf28a">
             hlineto
             -27 -131 rlineto
-            return
-        </CharString>
-        <CharString index="3" fingerprint="094a6dd1">
-            hlineto
-            74 -73 -2 -13 -40 -25 rlineto
             return
         </CharString>
         <CharString index="4" fingerprint="ebe0bd64">
@@ -32,37 +32,37 @@
             -27 -132 rlineto
             return
         </CharString>
-        <CharString index="5" fingerprint="2e3e492a">
-            {0294fbed} callsubr
+        <CharString index="5" fingerprint="9d6990a4">
+            {0a376d15} callsubr
             endchar
         </CharString>
-        <CharString index="6" fingerprint="0294fbed">
-            {ce9611a3} callgsubr
+        <CharString index="6" fingerprint="0a376d15">
+            {ce9611a3} callsubr
             rlineto
             return
         </CharString>
-        <CharString index="7" fingerprint="9ffb92b0">
+        <CharString index="7" fingerprint="ce9611a3">
+            {9ffb92b0} callsubr
+            24 130 return
+        </CharString>
+        <CharString index="8" fingerprint="9ffb92b0">
             63 -122 409 264 return
         </CharString>
     </Subrs>
     <GlobalSubrs>
-        <CharString index="0" fingerprint="d60c0b36">
-            {1deed8a2} callsubr
-            hstem
-            return
-        </CharString>
-        <CharString index="1" fingerprint="145d2e17">
+        <CharString index="0" fingerprint="145d2e17">
             132 111 131 return
         </CharString>
-        <CharString index="2" fingerprint="cf96d680">
+        <CharString index="1" fingerprint="cf96d680">
             vstem
             {ed114548} callsubr
             64 -63 rlineto
             return
         </CharString>
-        <CharString index="3" fingerprint="ce9611a3">
-            {9ffb92b0} callsubr
-            24 130 return
+        <CharString index="2" fingerprint="094a6dd1">
+            hlineto
+            74 -73 -2 -13 -40 -25 rlineto
+            return
         </CharString>
     </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_less_less.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/equal_less_less.liga.xml
@@ -1,0 +1,54 @@
+<Glyph name="equal_less_less.liga" lsb="-1199" width="625">
+    <CharString>
+        {1deed8a2} callsubr
+        hstemhm
+        -1199 1783 -916 496 -76 496 hintmask 11010000
+        -180 {ed539986} callsubr
+        -967 {fdbdf28a} callsubr
+        836 hlineto
+        -17 -96 14 -15 rlineto
+        -854 hlineto
+        hintmask 11100000
+        -27 -132 rlineto
+        1008 hlineto
+        172 -180 rlineto
+        hintmask 11001000
+        107 103 -270 268 rlineto
+        422 13 rmoveto
+        344 215 {acd73580} callgsubr
+        -270 268 rlineto
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="1deed8a2">
+            152 {145d2e17} callgsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="ed539986">
+            356 {a922991d} callsubr
+            -258 -167 rlineto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="a922991d">
+            rmoveto
+            344 215 -63 122 return
+        </CharString>
+        <CharString index="3" fingerprint="fdbdf28a">
+            hlineto
+            -27 -131 rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="e26cb4f3">
+            -63 122 -410 -265 -23 -129 313 -327 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="1" fingerprint="acd73580">
+            {e26cb4f3} callsubr
+            107 103 return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/exclam_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/exclam_equal.liga.xml
@@ -1,10 +1,10 @@
 <Glyph name="exclam_equal.liga" lsb="-574" width="625">
     <CharString>
-        {4465ff65} callgsubr
+        {4465ff65} callsubr
         -664 {145d2e17} callgsubr
         hstemhm
         -574 1172 -982 791 hintmask 01110000
-        572 {ea169de2} callsubr
+        572 {e17922fa} callsubr
         -351 hlineto
         hintmask 01101000
         160 240 rlineto
@@ -13,7 +13,7 @@
         hintmask 01101000
         -194 -290 rlineto
         -583 {fdbdf28a} callsubr
-        523 {558132c6} callgsubr
+        523 {558132c6} callsubr
         -470 {ebe0bd64} callsubr
         408 hlineto
         -218 -327 rlineto
@@ -21,59 +21,59 @@
         138 -40 rlineto
         hintmask 01001000
         244 367 rlineto
-        526 {800351b2} callgsubr
+        526 {800351b2} callsubr
         -465 hlineto
         hintmask 01101000
         74 111 rlineto
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="ea169de2">
-            395 {2b0429de} callsubr
-            return
-        </CharString>
-        <CharString index="1" fingerprint="2b0429de">
-            rmoveto
-            {d5a87c62} callgsubr
-            return
-        </CharString>
-        <CharString index="2" fingerprint="fb64a85a">
-            131 rlineto
-            return
-        </CharString>
-        <CharString index="3" fingerprint="fdbdf28a">
-            hlineto
-            -27 -131 rlineto
-            return
-        </CharString>
-        <CharString index="4" fingerprint="ebe0bd64">
-            hlineto
-            -27 -132 rlineto
-            return
-        </CharString>
-    </Subrs>
-    <GlobalSubrs>
         <CharString index="0" fingerprint="4465ff65">
             -215 1031 return
         </CharString>
-        <CharString index="1" fingerprint="145d2e17">
-            132 111 131 return
+        <CharString index="1" fingerprint="e17922fa">
+            395 {0d1be3e3} callgsubr
+            return
         </CharString>
         <CharString index="2" fingerprint="d5a87c62">
             26 {fb64a85a} callsubr
             return
         </CharString>
-        <CharString index="3" fingerprint="558132c6">
+        <CharString index="3" fingerprint="fb64a85a">
+            131 rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="fdbdf28a">
+            hlineto
+            -27 -131 rlineto
+            return
+        </CharString>
+        <CharString index="5" fingerprint="558132c6">
             hlineto
             -74 -111 rlineto
             return
         </CharString>
-        <CharString index="4" fingerprint="800351b2">
+        <CharString index="6" fingerprint="ebe0bd64">
+            hlineto
+            -27 -132 rlineto
+            return
+        </CharString>
+        <CharString index="7" fingerprint="800351b2">
             hlineto
             {b0652e66} callgsubr
             return
         </CharString>
-        <CharString index="5" fingerprint="b0652e66">
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="1" fingerprint="0d1be3e3">
+            rmoveto
+            {d5a87c62} callsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="b0652e66">
             27 132 rlineto
             return
         </CharString>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/exclam_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/exclam_equal.liga.xml
@@ -1,0 +1,81 @@
+<Glyph name="exclam_equal.liga" lsb="-574" width="625">
+    <CharString>
+        {4465ff65} callgsubr
+        -664 {145d2e17} callgsubr
+        hstemhm
+        -574 1172 -982 791 hintmask 01110000
+        572 {ea169de2} callsubr
+        -351 hlineto
+        hintmask 01101000
+        160 240 rlineto
+        hintmask 10001000
+        -129 50 rlineto
+        hintmask 01101000
+        -194 -290 rlineto
+        -583 {fdbdf28a} callsubr
+        523 {558132c6} callgsubr
+        -470 {ebe0bd64} callsubr
+        408 hlineto
+        -218 -327 rlineto
+        hintmask 10001000
+        138 -40 rlineto
+        hintmask 01001000
+        244 367 rlineto
+        526 {800351b2} callgsubr
+        -465 hlineto
+        hintmask 01101000
+        74 111 rlineto
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="ea169de2">
+            395 {2b0429de} callsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="2b0429de">
+            rmoveto
+            {d5a87c62} callgsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="fb64a85a">
+            131 rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="fdbdf28a">
+            hlineto
+            -27 -131 rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="ebe0bd64">
+            hlineto
+            -27 -132 rlineto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="4465ff65">
+            -215 1031 return
+        </CharString>
+        <CharString index="1" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="2" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
+            return
+        </CharString>
+        <CharString index="3" fingerprint="558132c6">
+            hlineto
+            -74 -111 rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="800351b2">
+            hlineto
+            {b0652e66} callgsubr
+            return
+        </CharString>
+        <CharString index="5" fingerprint="b0652e66">
+            27 132 rlineto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/exclam_equal_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/exclam_equal_equal.liga.xml
@@ -1,0 +1,82 @@
+<Glyph name="exclam_equal_equal.liga" lsb="-1223" width="625">
+    <CharString>
+        {4465ff65} callgsubr
+        -785 {145d2e17} callgsubr
+        112 131 hstemhm
+        -1223 1845 -1318 791 cntrmask 01110000
+        hintmask 01111000
+        596 517 {2b0429de} callsubr
+        -606 hlineto
+        hintmask 01110100
+        79 118 rlineto
+        hintmask 10000100
+        -129 50 rlineto
+        hintmask 01110100
+        -112 -168 rlineto
+        -954 {fdbdf28a} callsubr
+        893 {558132c6} callgsubr
+        -840 {ebe0bd64} callsubr
+        779 {558132c6} callgsubr
+        -726 {ebe0bd64} callsubr
+        665 hlineto
+        -138 -206 rlineto
+        hintmask 10000100
+        138 -40 rlineto
+        hintmask 01110100
+        164 246 rlineto
+        894 {800351b2} callgsubr
+        -833 hlineto
+        74 111 rlineto
+        780 {800351b2} callgsubr
+        -720 hlineto
+        74 111 rlineto
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="2b0429de">
+            rmoveto
+            {d5a87c62} callgsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="fb64a85a">
+            131 rlineto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="fdbdf28a">
+            hlineto
+            -27 -131 rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="ebe0bd64">
+            hlineto
+            -27 -132 rlineto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="4465ff65">
+            -215 1031 return
+        </CharString>
+        <CharString index="1" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="2" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
+            return
+        </CharString>
+        <CharString index="3" fingerprint="558132c6">
+            hlineto
+            -74 -111 rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="800351b2">
+            hlineto
+            {b0652e66} callgsubr
+            return
+        </CharString>
+        <CharString index="5" fingerprint="b0652e66">
+            27 132 rlineto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/exclam_equal_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/exclam_equal_equal.liga.xml
@@ -1,11 +1,11 @@
 <Glyph name="exclam_equal_equal.liga" lsb="-1223" width="625">
     <CharString>
-        {4465ff65} callgsubr
+        {4465ff65} callsubr
         -785 {145d2e17} callgsubr
         112 131 hstemhm
         -1223 1845 -1318 791 cntrmask 01110000
         hintmask 01111000
-        596 517 {2b0429de} callsubr
+        596 517 {0d1be3e3} callgsubr
         -606 hlineto
         hintmask 01110100
         79 118 rlineto
@@ -14,9 +14,9 @@
         hintmask 01110100
         -112 -168 rlineto
         -954 {fdbdf28a} callsubr
-        893 {558132c6} callgsubr
+        893 {558132c6} callsubr
         -840 {ebe0bd64} callsubr
-        779 {558132c6} callgsubr
+        779 {558132c6} callsubr
         -726 {ebe0bd64} callsubr
         665 hlineto
         -138 -206 rlineto
@@ -24,57 +24,57 @@
         138 -40 rlineto
         hintmask 01110100
         164 246 rlineto
-        894 {800351b2} callgsubr
+        894 {800351b2} callsubr
         -833 hlineto
         74 111 rlineto
-        780 {800351b2} callgsubr
+        780 {800351b2} callsubr
         -720 hlineto
         74 111 rlineto
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="2b0429de">
-            rmoveto
-            {d5a87c62} callgsubr
+        <CharString index="0" fingerprint="4465ff65">
+            -215 1031 return
+        </CharString>
+        <CharString index="1" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
             return
         </CharString>
-        <CharString index="1" fingerprint="fb64a85a">
+        <CharString index="2" fingerprint="fb64a85a">
             131 rlineto
             return
         </CharString>
-        <CharString index="2" fingerprint="fdbdf28a">
+        <CharString index="3" fingerprint="fdbdf28a">
             hlineto
             -27 -131 rlineto
             return
         </CharString>
-        <CharString index="3" fingerprint="ebe0bd64">
-            hlineto
-            -27 -132 rlineto
-            return
-        </CharString>
-    </Subrs>
-    <GlobalSubrs>
-        <CharString index="0" fingerprint="4465ff65">
-            -215 1031 return
-        </CharString>
-        <CharString index="1" fingerprint="145d2e17">
-            132 111 131 return
-        </CharString>
-        <CharString index="2" fingerprint="d5a87c62">
-            26 {fb64a85a} callsubr
-            return
-        </CharString>
-        <CharString index="3" fingerprint="558132c6">
+        <CharString index="4" fingerprint="558132c6">
             hlineto
             -74 -111 rlineto
             return
         </CharString>
-        <CharString index="4" fingerprint="800351b2">
+        <CharString index="5" fingerprint="ebe0bd64">
+            hlineto
+            -27 -132 rlineto
+            return
+        </CharString>
+        <CharString index="6" fingerprint="800351b2">
             hlineto
             {b0652e66} callgsubr
             return
         </CharString>
-        <CharString index="5" fingerprint="b0652e66">
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="1" fingerprint="0d1be3e3">
+            rmoveto
+            {d5a87c62} callsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="b0652e66">
             27 132 rlineto
             return
         </CharString>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/greater_equal_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/greater_equal_greater.liga.xml
@@ -6,13 +6,13 @@
         64 -63 rlineto
         -1047 hlineto
         -160 167 {d021177f} callsubr
-        {3c2302fa} callgsubr
+        {3c2302fa} callsubr
         1001 hlineto
         hintmask 11101000
         -93 -58 {9ffb92b0} callsubr
         rlineto
         hintmask 11010000
-        {d4f80b1e} callsubr
+        {d4f80b1e} callgsubr
         -40 -25 rlineto
         -1073 hlineto
         hintmask 11100000
@@ -38,21 +38,21 @@
         <CharString index="3" fingerprint="d021177f">
             -107 -104 270 -267 -2 -13 return
         </CharString>
-        <CharString index="4" fingerprint="9ffb92b0">
-            63 -122 409 264 return
-        </CharString>
-        <CharString index="5" fingerprint="d4f80b1e">
-            24 130 rlineto
-            -152 -57 rmoveto
+        <CharString index="4" fingerprint="3c2302fa">
+            -344 -215 63 -122 279 180 rlineto
             return
+        </CharString>
+        <CharString index="5" fingerprint="9ffb92b0">
+            63 -122 409 264 return
         </CharString>
     </Subrs>
     <GlobalSubrs>
         <CharString index="0" fingerprint="145d2e17">
             132 111 131 return
         </CharString>
-        <CharString index="1" fingerprint="3c2302fa">
-            -344 -215 63 -122 279 180 rlineto
+        <CharString index="1" fingerprint="d4f80b1e">
+            24 130 rlineto
+            -152 -57 rmoveto
             return
         </CharString>
     </GlobalSubrs>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/greater_equal_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/greater_equal_greater.liga.xml
@@ -1,0 +1,59 @@
+<Glyph name="greater_equal_greater.liga" lsb="-1187" width="625">
+    <CharString>
+        {688d9a51} callsubr
+        1746 -496 496 hintmask 11100000
+        {ed114548} callsubr
+        64 -63 rlineto
+        -1047 hlineto
+        -160 167 {d021177f} callsubr
+        {3c2302fa} callgsubr
+        1001 hlineto
+        hintmask 11101000
+        -93 -58 {9ffb92b0} callsubr
+        rlineto
+        hintmask 11010000
+        {d4f80b1e} callsubr
+        -40 -25 rlineto
+        -1073 hlineto
+        hintmask 11100000
+        15 82 -28 29 rlineto
+        1054 hlineto
+        74 -73 rlineto
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="688d9a51">
+            {1deed8a2} callsubr
+            hstemhm
+            -1187 496 -496 return
+        </CharString>
+        <CharString index="1" fingerprint="1deed8a2">
+            152 {145d2e17} callgsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="ed114548">
+            246 693 rmoveto
+            -107 -104 return
+        </CharString>
+        <CharString index="3" fingerprint="d021177f">
+            -107 -104 270 -267 -2 -13 return
+        </CharString>
+        <CharString index="4" fingerprint="9ffb92b0">
+            63 -122 409 264 return
+        </CharString>
+        <CharString index="5" fingerprint="d4f80b1e">
+            24 130 rlineto
+            -152 -57 rmoveto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="1" fingerprint="3c2302fa">
+            -344 -215 63 -122 279 180 rlineto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/greater_greater_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/greater_greater_equal.liga.xml
@@ -1,0 +1,60 @@
+<Glyph name="greater_greater_equal.liga" lsb="-1187" width="625">
+    <CharString>
+        {688d9a51} callsubr
+        1785 -1365 496 hintmask 11100000
+        -691 366 rmoveto
+        -313 327 {d021177f} callsubr
+        rlineto
+        hintmask 11010000
+        -344 -215 {9ffb92b0} callsubr
+        rlineto
+        1313 290 rmoveto
+        -1022 hlineto
+        -160 167 rlineto
+        hintmask 11100000
+        {d021177f} callsubr
+        rlineto
+        hintmask 11001000
+        {3c2302fa} callgsubr
+        949 {800351b2} callgsubr
+        -837 hlineto
+        15 82 -28 29 rlineto
+        871 hlineto
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="688d9a51">
+            {1deed8a2} callsubr
+            hstemhm
+            -1187 496 -496 return
+        </CharString>
+        <CharString index="1" fingerprint="1deed8a2">
+            152 {145d2e17} callgsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="d021177f">
+            -107 -104 270 -267 -2 -13 return
+        </CharString>
+        <CharString index="3" fingerprint="9ffb92b0">
+            63 -122 409 264 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="1" fingerprint="3c2302fa">
+            -344 -215 63 -122 279 180 rlineto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="800351b2">
+            hlineto
+            {b0652e66} callgsubr
+            return
+        </CharString>
+        <CharString index="3" fingerprint="b0652e66">
+            27 132 rlineto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/greater_greater_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/greater_greater_equal.liga.xml
@@ -15,8 +15,8 @@
         {d021177f} callsubr
         rlineto
         hintmask 11001000
-        {3c2302fa} callgsubr
-        949 {800351b2} callgsubr
+        {3c2302fa} callsubr
+        949 {800351b2} callsubr
         -837 hlineto
         15 82 -28 29 rlineto
         871 hlineto
@@ -38,21 +38,21 @@
         <CharString index="3" fingerprint="9ffb92b0">
             63 -122 409 264 return
         </CharString>
+        <CharString index="4" fingerprint="3c2302fa">
+            -344 -215 63 -122 279 180 rlineto
+            return
+        </CharString>
+        <CharString index="5" fingerprint="800351b2">
+            hlineto
+            {b0652e66} callgsubr
+            return
+        </CharString>
     </Subrs>
     <GlobalSubrs>
         <CharString index="0" fingerprint="145d2e17">
             132 111 131 return
         </CharString>
-        <CharString index="1" fingerprint="3c2302fa">
-            -344 -215 63 -122 279 180 rlineto
-            return
-        </CharString>
-        <CharString index="2" fingerprint="800351b2">
-            hlineto
-            {b0652e66} callgsubr
-            return
-        </CharString>
-        <CharString index="3" fingerprint="b0652e66">
+        <CharString index="1" fingerprint="b0652e66">
             27 132 rlineto
             return
         </CharString>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/hyphen_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/hyphen_greater.liga.xml
@@ -1,51 +1,50 @@
 <Glyph name="hyphen_greater.liga" lsb="-484" width="625">
     <CharString>
-        {74339e1b} callgsubr
+        {74339e1b} callsubr
         -484 1043 {5e871159} callsubr
-        -784 {2e97c44c} callgsubr
-        827 {35be0eb8} callsubr
+        -784 {2e97c44c} callsubr
+        827 {e3d5b7cd} callsubr
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="5e871159">
+        <CharString index="0" fingerprint="74339e1b">
+            269 134 hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="5e871159">
             vstem
             {ed114548} callsubr
             188 -186 rlineto
             return
         </CharString>
-        <CharString index="1" fingerprint="ed114548">
+        <CharString index="2" fingerprint="ed114548">
             246 693 rmoveto
             -107 -104 return
         </CharString>
-        <CharString index="2" fingerprint="35be0eb8">
-            hlineto
-            -280 -175 {2e3e492a} callsubr
-        </CharString>
-        <CharString index="3" fingerprint="2e3e492a">
-            {0294fbed} callsubr
-            endchar
-        </CharString>
-        <CharString index="4" fingerprint="0294fbed">
-            {ce9611a3} callgsubr
-            rlineto
-            return
-        </CharString>
-        <CharString index="5" fingerprint="9ffb92b0">
-            63 -122 409 264 return
-        </CharString>
-    </Subrs>
-    <GlobalSubrs>
-        <CharString index="0" fingerprint="74339e1b">
-            269 134 hstem
-            return
-        </CharString>
-        <CharString index="1" fingerprint="2e97c44c">
+        <CharString index="3" fingerprint="2e97c44c">
             hlineto
             -27 -134 rlineto
             return
         </CharString>
-        <CharString index="2" fingerprint="ce9611a3">
+        <CharString index="4" fingerprint="e3d5b7cd">
+            hlineto
+            -280 -175 {9d6990a4} callsubr
+        </CharString>
+        <CharString index="5" fingerprint="9d6990a4">
+            {0a376d15} callsubr
+            endchar
+        </CharString>
+        <CharString index="6" fingerprint="0a376d15">
+            {ce9611a3} callsubr
+            rlineto
+            return
+        </CharString>
+        <CharString index="7" fingerprint="ce9611a3">
             {9ffb92b0} callsubr
             24 130 return
         </CharString>
-    </GlobalSubrs>
+        <CharString index="8" fingerprint="9ffb92b0">
+            63 -122 409 264 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs/>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/hyphen_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/hyphen_greater.liga.xml
@@ -1,0 +1,51 @@
+<Glyph name="hyphen_greater.liga" lsb="-484" width="625">
+    <CharString>
+        {74339e1b} callgsubr
+        -484 1043 {5e871159} callsubr
+        -784 {2e97c44c} callgsubr
+        827 {35be0eb8} callsubr
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="5e871159">
+            vstem
+            {ed114548} callsubr
+            188 -186 rlineto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="ed114548">
+            246 693 rmoveto
+            -107 -104 return
+        </CharString>
+        <CharString index="2" fingerprint="35be0eb8">
+            hlineto
+            -280 -175 {2e3e492a} callsubr
+        </CharString>
+        <CharString index="3" fingerprint="2e3e492a">
+            {0294fbed} callsubr
+            endchar
+        </CharString>
+        <CharString index="4" fingerprint="0294fbed">
+            {ce9611a3} callgsubr
+            rlineto
+            return
+        </CharString>
+        <CharString index="5" fingerprint="9ffb92b0">
+            63 -122 409 264 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="74339e1b">
+            269 134 hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="2e97c44c">
+            hlineto
+            -27 -134 rlineto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="ce9611a3">
+            {9ffb92b0} callsubr
+            24 130 return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/hyphen_hyphen.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/hyphen_hyphen.liga.xml
@@ -1,0 +1,28 @@
+<Glyph name="hyphen_hyphen.liga" lsb="-407" width="625">
+    <CharString>
+        {74339e1b} callgsubr
+        -407 366 103 366 vstem
+        -67 269 rmoveto
+        {d0c326a1} callgsubr
+        809 hmoveto
+        {d0c326a1} callgsubr
+        endchar
+    </CharString>
+    <Subrs/>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="74339e1b">
+            269 134 hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="d0c326a1">
+            26 134 rlineto
+            -339 {2e97c44c} callgsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="2e97c44c">
+            hlineto
+            -27 -134 rlineto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/hyphen_hyphen.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/hyphen_hyphen.liga.xml
@@ -1,22 +1,21 @@
 <Glyph name="hyphen_hyphen.liga" lsb="-407" width="625">
     <CharString>
-        {74339e1b} callgsubr
+        {74339e1b} callsubr
         -407 366 103 366 vstem
         -67 269 rmoveto
-        {d0c326a1} callgsubr
+        {83dff4bc} callsubr
         809 hmoveto
-        {d0c326a1} callgsubr
+        {83dff4bc} callsubr
         endchar
     </CharString>
-    <Subrs/>
-    <GlobalSubrs>
+    <Subrs>
         <CharString index="0" fingerprint="74339e1b">
             269 134 hstem
             return
         </CharString>
-        <CharString index="1" fingerprint="d0c326a1">
+        <CharString index="1" fingerprint="83dff4bc">
             26 134 rlineto
-            -339 {2e97c44c} callgsubr
+            -339 {2e97c44c} callsubr
             return
         </CharString>
         <CharString index="2" fingerprint="2e97c44c">
@@ -24,5 +23,6 @@
             -27 -134 rlineto
             return
         </CharString>
-    </GlobalSubrs>
+    </Subrs>
+    <GlobalSubrs/>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/hyphen_hyphen_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/hyphen_hyphen_greater.liga.xml
@@ -1,51 +1,50 @@
 <Glyph name="hyphen_hyphen_greater.liga" lsb="-1109" width="625">
     <CharString>
-        {74339e1b} callgsubr
+        {74339e1b} callsubr
         -1109 1668 {5e871159} callsubr
-        -1409 {2e97c44c} callgsubr
-        1452 {35be0eb8} callsubr
+        -1409 {2e97c44c} callsubr
+        1452 {e3d5b7cd} callsubr
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="5e871159">
+        <CharString index="0" fingerprint="74339e1b">
+            269 134 hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="5e871159">
             vstem
             {ed114548} callsubr
             188 -186 rlineto
             return
         </CharString>
-        <CharString index="1" fingerprint="ed114548">
+        <CharString index="2" fingerprint="ed114548">
             246 693 rmoveto
             -107 -104 return
         </CharString>
-        <CharString index="2" fingerprint="35be0eb8">
-            hlineto
-            -280 -175 {2e3e492a} callsubr
-        </CharString>
-        <CharString index="3" fingerprint="2e3e492a">
-            {0294fbed} callsubr
-            endchar
-        </CharString>
-        <CharString index="4" fingerprint="0294fbed">
-            {ce9611a3} callgsubr
-            rlineto
-            return
-        </CharString>
-        <CharString index="5" fingerprint="9ffb92b0">
-            63 -122 409 264 return
-        </CharString>
-    </Subrs>
-    <GlobalSubrs>
-        <CharString index="0" fingerprint="74339e1b">
-            269 134 hstem
-            return
-        </CharString>
-        <CharString index="1" fingerprint="2e97c44c">
+        <CharString index="3" fingerprint="2e97c44c">
             hlineto
             -27 -134 rlineto
             return
         </CharString>
-        <CharString index="2" fingerprint="ce9611a3">
+        <CharString index="4" fingerprint="e3d5b7cd">
+            hlineto
+            -280 -175 {9d6990a4} callsubr
+        </CharString>
+        <CharString index="5" fingerprint="9d6990a4">
+            {0a376d15} callsubr
+            endchar
+        </CharString>
+        <CharString index="6" fingerprint="0a376d15">
+            {ce9611a3} callsubr
+            rlineto
+            return
+        </CharString>
+        <CharString index="7" fingerprint="ce9611a3">
             {9ffb92b0} callsubr
             24 130 return
         </CharString>
-    </GlobalSubrs>
+        <CharString index="8" fingerprint="9ffb92b0">
+            63 -122 409 264 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs/>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/hyphen_hyphen_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/hyphen_hyphen_greater.liga.xml
@@ -1,0 +1,51 @@
+<Glyph name="hyphen_hyphen_greater.liga" lsb="-1109" width="625">
+    <CharString>
+        {74339e1b} callgsubr
+        -1109 1668 {5e871159} callsubr
+        -1409 {2e97c44c} callgsubr
+        1452 {35be0eb8} callsubr
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="5e871159">
+            vstem
+            {ed114548} callsubr
+            188 -186 rlineto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="ed114548">
+            246 693 rmoveto
+            -107 -104 return
+        </CharString>
+        <CharString index="2" fingerprint="35be0eb8">
+            hlineto
+            -280 -175 {2e3e492a} callsubr
+        </CharString>
+        <CharString index="3" fingerprint="2e3e492a">
+            {0294fbed} callsubr
+            endchar
+        </CharString>
+        <CharString index="4" fingerprint="0294fbed">
+            {ce9611a3} callgsubr
+            rlineto
+            return
+        </CharString>
+        <CharString index="5" fingerprint="9ffb92b0">
+            63 -122 409 264 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="74339e1b">
+            269 134 hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="2e97c44c">
+            hlineto
+            -27 -134 rlineto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="ce9611a3">
+            {9ffb92b0} callsubr
+            24 130 return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_bar.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_bar.liga.xml
@@ -1,0 +1,14 @@
+<Glyph name="less_bar.liga" lsb="-376" width="625">
+    <CharString>
+        -376 738 vstem
+        214 795 rmoveto
+        -567 -367 -23 -129 396 -502 rlineto
+        147 hlineto
+        195 1001 rlineto
+        -305 -810 rmoveto
+        -283 355 2 13 402 254 rlineto
+        endchar
+    </CharString>
+    <Subrs/>
+    <GlobalSubrs/>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_equal_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_equal_equal.liga.xml
@@ -4,13 +4,13 @@
         hstemhm
         -1162 496 -496 1760 hintmask 11010000
         -948 395 rmoveto
-        1520 {4ff4d421} callsubr
+        1520 {256033b9} callsubr
         -1336 hlineto
         hintmask 11100000
         72 45 -63 122 -410 -265 rlineto
         hintmask 11010000
         -23 -129 313 -327 107 103 -78 77 rlineto
-        1344 {800351b2} callgsubr
+        1344 {800351b2} callsubr
         -1504 hlineto
         -59 59 2 13 rlineto
         endchar
@@ -20,13 +20,22 @@
             152 {145d2e17} callgsubr
             return
         </CharString>
-        <CharString index="1" fingerprint="4ff4d421">
+        <CharString index="1" fingerprint="256033b9">
             hlineto
-            {d5a87c62} callgsubr
+            {d5a87c62} callsubr
             return
         </CharString>
-        <CharString index="2" fingerprint="fb64a85a">
+        <CharString index="2" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
+            return
+        </CharString>
+        <CharString index="3" fingerprint="fb64a85a">
             131 rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="800351b2">
+            hlineto
+            {b0652e66} callgsubr
             return
         </CharString>
     </Subrs>
@@ -34,16 +43,7 @@
         <CharString index="0" fingerprint="145d2e17">
             132 111 131 return
         </CharString>
-        <CharString index="1" fingerprint="d5a87c62">
-            26 {fb64a85a} callsubr
-            return
-        </CharString>
-        <CharString index="2" fingerprint="800351b2">
-            hlineto
-            {b0652e66} callgsubr
-            return
-        </CharString>
-        <CharString index="3" fingerprint="b0652e66">
+        <CharString index="1" fingerprint="b0652e66">
             27 132 rlineto
             return
         </CharString>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_equal_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_equal_equal.liga.xml
@@ -1,0 +1,51 @@
+<Glyph name="less_equal_equal.liga" lsb="-1162" width="625">
+    <CharString>
+        {1deed8a2} callsubr
+        hstemhm
+        -1162 496 -496 1760 hintmask 11010000
+        -948 395 rmoveto
+        1520 {4ff4d421} callsubr
+        -1336 hlineto
+        hintmask 11100000
+        72 45 -63 122 -410 -265 rlineto
+        hintmask 11010000
+        -23 -129 313 -327 107 103 -78 77 rlineto
+        1344 {800351b2} callgsubr
+        -1504 hlineto
+        -59 59 2 13 rlineto
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="1deed8a2">
+            152 {145d2e17} callgsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="4ff4d421">
+            hlineto
+            {d5a87c62} callgsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="fb64a85a">
+            131 rlineto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="1" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="800351b2">
+            hlineto
+            {b0652e66} callgsubr
+            return
+        </CharString>
+        <CharString index="3" fingerprint="b0652e66">
+            27 132 rlineto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_equal_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_equal_greater.liga.xml
@@ -1,0 +1,67 @@
+<Glyph name="less_equal_greater.liga" lsb="-1162" width="625">
+    <CharString>
+        {d60c0b36} callgsubr
+        -1162 1721 {cf96d680} callgsubr
+        -941 {d494bf67} callsubr
+        976 hlineto
+        -93 -58 {0294fbed} callsubr
+        -152 -57 rmoveto
+        -40 -25 rlineto
+        -1320 hlineto
+        -59 59 2 13 62 39 rlineto
+        1283 hlineto
+        74 -73 rlineto
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="1deed8a2">
+            152 {145d2e17} callgsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="ed114548">
+            246 693 rmoveto
+            -107 -104 return
+        </CharString>
+        <CharString index="2" fingerprint="d494bf67">
+            hlineto
+            72 45 {acd73580} callgsubr
+            -78 77 rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="e26cb4f3">
+            -63 122 -410 -265 -23 -129 313 -327 return
+        </CharString>
+        <CharString index="4" fingerprint="0294fbed">
+            {ce9611a3} callgsubr
+            rlineto
+            return
+        </CharString>
+        <CharString index="5" fingerprint="9ffb92b0">
+            63 -122 409 264 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="d60c0b36">
+            {1deed8a2} callsubr
+            hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="2" fingerprint="cf96d680">
+            vstem
+            {ed114548} callsubr
+            64 -63 rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="acd73580">
+            {e26cb4f3} callsubr
+            107 103 return
+        </CharString>
+        <CharString index="4" fingerprint="ce9611a3">
+            {9ffb92b0} callsubr
+            24 130 return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_equal_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_equal_greater.liga.xml
@@ -1,10 +1,10 @@
 <Glyph name="less_equal_greater.liga" lsb="-1162" width="625">
     <CharString>
-        {d60c0b36} callgsubr
+        {d60c0b36} callsubr
         -1162 1721 {cf96d680} callgsubr
         -941 {d494bf67} callsubr
         976 hlineto
-        -93 -58 {0294fbed} callsubr
+        -93 -58 {0a376d15} callsubr
         -152 -57 rmoveto
         -40 -25 rlineto
         -1320 hlineto
@@ -14,54 +14,54 @@
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="1deed8a2">
-            152 {145d2e17} callgsubr
-            return
-        </CharString>
-        <CharString index="1" fingerprint="ed114548">
-            246 693 rmoveto
-            -107 -104 return
-        </CharString>
-        <CharString index="2" fingerprint="d494bf67">
-            hlineto
-            72 45 {acd73580} callgsubr
-            -78 77 rlineto
-            return
-        </CharString>
-        <CharString index="3" fingerprint="e26cb4f3">
-            -63 122 -410 -265 -23 -129 313 -327 return
-        </CharString>
-        <CharString index="4" fingerprint="0294fbed">
-            {ce9611a3} callgsubr
-            rlineto
-            return
-        </CharString>
-        <CharString index="5" fingerprint="9ffb92b0">
-            63 -122 409 264 return
-        </CharString>
-    </Subrs>
-    <GlobalSubrs>
         <CharString index="0" fingerprint="d60c0b36">
             {1deed8a2} callsubr
             hstem
             return
         </CharString>
-        <CharString index="1" fingerprint="145d2e17">
+        <CharString index="1" fingerprint="1deed8a2">
+            152 {145d2e17} callgsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="ed114548">
+            246 693 rmoveto
+            -107 -104 return
+        </CharString>
+        <CharString index="3" fingerprint="d494bf67">
+            hlineto
+            72 45 {acd73580} callgsubr
+            -78 77 rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="e26cb4f3">
+            -63 122 -410 -265 -23 -129 313 -327 return
+        </CharString>
+        <CharString index="5" fingerprint="0a376d15">
+            {ce9611a3} callsubr
+            rlineto
+            return
+        </CharString>
+        <CharString index="6" fingerprint="ce9611a3">
+            {9ffb92b0} callsubr
+            24 130 return
+        </CharString>
+        <CharString index="7" fingerprint="9ffb92b0">
+            63 -122 409 264 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="145d2e17">
             132 111 131 return
         </CharString>
-        <CharString index="2" fingerprint="cf96d680">
+        <CharString index="1" fingerprint="cf96d680">
             vstem
             {ed114548} callsubr
             64 -63 rlineto
             return
         </CharString>
-        <CharString index="3" fingerprint="acd73580">
+        <CharString index="2" fingerprint="acd73580">
             {e26cb4f3} callsubr
             107 103 return
-        </CharString>
-        <CharString index="4" fingerprint="ce9611a3">
-            {9ffb92b0} callsubr
-            24 130 return
         </CharString>
     </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_equal_less.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_equal_less.liga.xml
@@ -1,6 +1,6 @@
 <Glyph name="less_equal_less.liga" lsb="-1162" width="625">
     <CharString>
-        {d60c0b36} callgsubr
+        {d60c0b36} callsubr
         -1162 1746 vstem
         240 {ed539986} callsubr
         -1001 {d494bf67} callsubr
@@ -13,39 +13,39 @@
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="1deed8a2">
-            152 {145d2e17} callgsubr
-            return
-        </CharString>
-        <CharString index="1" fingerprint="ed539986">
-            356 {a922991d} callsubr
-            -258 -167 rlineto
-            return
-        </CharString>
-        <CharString index="2" fingerprint="a922991d">
-            rmoveto
-            344 215 -63 122 return
-        </CharString>
-        <CharString index="3" fingerprint="d494bf67">
-            hlineto
-            72 45 {acd73580} callgsubr
-            -78 77 rlineto
-            return
-        </CharString>
-        <CharString index="4" fingerprint="e26cb4f3">
-            -63 122 -410 -265 -23 -129 313 -327 return
-        </CharString>
-    </Subrs>
-    <GlobalSubrs>
         <CharString index="0" fingerprint="d60c0b36">
             {1deed8a2} callsubr
             hstem
             return
         </CharString>
-        <CharString index="1" fingerprint="145d2e17">
+        <CharString index="1" fingerprint="1deed8a2">
+            152 {145d2e17} callgsubr
+            return
+        </CharString>
+        <CharString index="2" fingerprint="ed539986">
+            356 {a922991d} callsubr
+            -258 -167 rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="a922991d">
+            rmoveto
+            344 215 -63 122 return
+        </CharString>
+        <CharString index="4" fingerprint="d494bf67">
+            hlineto
+            72 45 {acd73580} callgsubr
+            -78 77 rlineto
+            return
+        </CharString>
+        <CharString index="5" fingerprint="e26cb4f3">
+            -63 122 -410 -265 -23 -129 313 -327 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="145d2e17">
             132 111 131 return
         </CharString>
-        <CharString index="2" fingerprint="acd73580">
+        <CharString index="1" fingerprint="acd73580">
             {e26cb4f3} callsubr
             107 103 return
         </CharString>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_equal_less.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_equal_less.liga.xml
@@ -1,0 +1,53 @@
+<Glyph name="less_equal_less.liga" lsb="-1162" width="625">
+    <CharString>
+        {d60c0b36} callgsubr
+        -1162 1746 vstem
+        240 {ed539986} callsubr
+        -1001 {d494bf67} callsubr
+        1049 hlineto
+        172 -180 107 103 -270 268 rlineto
+        -1191 -59 rmoveto
+        -59 59 2 13 62 39 rlineto
+        1053 hlineto
+        -17 -96 14 -15 rlineto
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="1deed8a2">
+            152 {145d2e17} callgsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="ed539986">
+            356 {a922991d} callsubr
+            -258 -167 rlineto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="a922991d">
+            rmoveto
+            344 215 -63 122 return
+        </CharString>
+        <CharString index="3" fingerprint="d494bf67">
+            hlineto
+            72 45 {acd73580} callgsubr
+            -78 77 rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="e26cb4f3">
+            -63 122 -410 -265 -23 -129 313 -327 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="d60c0b36">
+            {1deed8a2} callsubr
+            hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="145d2e17">
+            132 111 131 return
+        </CharString>
+        <CharString index="2" fingerprint="acd73580">
+            {e26cb4f3} callsubr
+            107 103 return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_exclam_hyphen_hyphen.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_exclam_hyphen_hyphen.liga.xml
@@ -1,0 +1,42 @@
+<Glyph name="less_exclam_hyphen_hyphen.liga" lsb="-1787" width="625">
+    <CharString>
+        0 171 98 134 hstem
+        -1787 496 250 343 839 366 vstem
+        -698 753 rmoveto
+        -200 hlineto
+        -44 -468 rlineto
+        104 hlineto
+        -202 118 rmoveto
+        -520 {8190eb7b} callgsubr
+        496 hlineto
+        365 134 rmoveto
+        -27 -134 rlineto
+        1209 hlineto
+        26 134 rlineto
+        -1548 -403 {77357c31} callsubr
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="e26cb4f3">
+            -63 122 -410 -265 -23 -129 313 -327 return
+        </CharString>
+        <CharString index="1" fingerprint="77357c31">
+            rmoveto
+            183 hlineto
+            34 171 rlineto
+            -184 hlineto
+            endchar
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="8190eb7b">
+            hlineto
+            269 168 {acd73580} callgsubr
+            -195 194 rlineto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="acd73580">
+            {e26cb4f3} callsubr
+            107 103 return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_hyphen.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_hyphen.liga.xml
@@ -1,6 +1,6 @@
 <Glyph name="less_hyphen.liga" lsb="-537" width="625">
     <CharString>
-        {74339e1b} callgsubr
+        {74339e1b} callsubr
         -537 1044 vstem
         507 403 rmoveto
         -817 {8190eb7b} callgsubr
@@ -8,22 +8,22 @@
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="e26cb4f3">
-            -63 122 -410 -265 -23 -129 313 -327 return
-        </CharString>
-    </Subrs>
-    <GlobalSubrs>
         <CharString index="0" fingerprint="74339e1b">
             269 134 hstem
             return
         </CharString>
-        <CharString index="1" fingerprint="8190eb7b">
+        <CharString index="1" fingerprint="e26cb4f3">
+            -63 122 -410 -265 -23 -129 313 -327 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="8190eb7b">
             hlineto
             269 168 {acd73580} callgsubr
             -195 194 rlineto
             return
         </CharString>
-        <CharString index="2" fingerprint="acd73580">
+        <CharString index="1" fingerprint="acd73580">
             {e26cb4f3} callsubr
             107 103 return
         </CharString>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_hyphen.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_hyphen.liga.xml
@@ -1,0 +1,31 @@
+<Glyph name="less_hyphen.liga" lsb="-537" width="625">
+    <CharString>
+        {74339e1b} callgsubr
+        -537 1044 vstem
+        507 403 rmoveto
+        -817 {8190eb7b} callgsubr
+        793 hlineto
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="e26cb4f3">
+            -63 122 -410 -265 -23 -129 313 -327 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="74339e1b">
+            269 134 hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="8190eb7b">
+            hlineto
+            269 168 {acd73580} callgsubr
+            -195 194 rlineto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="acd73580">
+            {e26cb4f3} callsubr
+            107 103 return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_hyphen_hyphen.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_hyphen_hyphen.liga.xml
@@ -1,6 +1,6 @@
 <Glyph name="less_hyphen_hyphen.liga" lsb="-1162" width="625">
     <CharString>
-        {74339e1b} callgsubr
+        {74339e1b} callsubr
         -1162 1669 vstem
         507 403 rmoveto
         -1442 {8190eb7b} callgsubr
@@ -8,22 +8,22 @@
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="e26cb4f3">
-            -63 122 -410 -265 -23 -129 313 -327 return
-        </CharString>
-    </Subrs>
-    <GlobalSubrs>
         <CharString index="0" fingerprint="74339e1b">
             269 134 hstem
             return
         </CharString>
-        <CharString index="1" fingerprint="8190eb7b">
+        <CharString index="1" fingerprint="e26cb4f3">
+            -63 122 -410 -265 -23 -129 313 -327 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="8190eb7b">
             hlineto
             269 168 {acd73580} callgsubr
             -195 194 rlineto
             return
         </CharString>
-        <CharString index="2" fingerprint="acd73580">
+        <CharString index="1" fingerprint="acd73580">
             {e26cb4f3} callsubr
             107 103 return
         </CharString>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_hyphen_hyphen.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_hyphen_hyphen.liga.xml
@@ -1,0 +1,31 @@
+<Glyph name="less_hyphen_hyphen.liga" lsb="-1162" width="625">
+    <CharString>
+        {74339e1b} callgsubr
+        -1162 1669 vstem
+        507 403 rmoveto
+        -1442 {8190eb7b} callgsubr
+        1418 hlineto
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="e26cb4f3">
+            -63 122 -410 -265 -23 -129 313 -327 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="74339e1b">
+            269 134 hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="8190eb7b">
+            hlineto
+            269 168 {acd73580} callgsubr
+            -195 194 rlineto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="acd73580">
+            {e26cb4f3} callsubr
+            107 103 return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_slash.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_slash.liga.xml
@@ -1,6 +1,6 @@
 <Glyph name="less_slash.liga" lsb="-537" width="625">
     <CharString>
-        {4465ff65} callgsubr
+        {4465ff65} callsubr
         hstemhm
         -537 496 -282 791 hintmask 10100000
         339 816 rmoveto
@@ -13,13 +13,12 @@
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="e26cb4f3">
-            -63 122 -410 -265 -23 -129 313 -327 return
-        </CharString>
-    </Subrs>
-    <GlobalSubrs>
         <CharString index="0" fingerprint="4465ff65">
             -215 1031 return
         </CharString>
-    </GlobalSubrs>
+        <CharString index="1" fingerprint="e26cb4f3">
+            -63 122 -410 -265 -23 -129 313 -327 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs/>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_slash.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/less_slash.liga.xml
@@ -1,0 +1,25 @@
+<Glyph name="less_slash.liga" lsb="-537" width="625">
+    <CharString>
+        {4465ff65} callgsubr
+        hstemhm
+        -537 496 -282 791 hintmask 10100000
+        339 816 rmoveto
+        -479 -718 -247 245 2 13 rlineto
+        hintmask 11000000
+        344 215 {e26cb4f3} callsubr
+        rlineto
+        hintmask 10100000
+        -99 -147 138 -40 653 981 rlineto
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="e26cb4f3">
+            -63 122 -410 -265 -23 -129 313 -327 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="4465ff65">
+            -215 1031 return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/plus_plus.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/plus_plus.liga.xml
@@ -1,0 +1,63 @@
+<Glyph name="plus_plus.liga" lsb="-501" width="625">
+    <CharString>
+        {ac63e3f4} callgsubr
+        -3 525 vstem
+        342 402 rmoveto
+        {58a7b0aa} callgsubr
+        -359 {f3ea7dc6} callsubr
+        37 189 rlineto
+        359 {406c29c7} callgsubr
+        37 189 rlineto
+        179 {4ff4d421} callsubr
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="f3ea7dc6">
+            hlineto
+            {58a7b0aa} callgsubr
+            -179 {fdbdf28a} callsubr
+            181 {406c29c7} callgsubr
+            return
+        </CharString>
+        <CharString index="1" fingerprint="fdbdf28a">
+            hlineto
+            -27 -131 rlineto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="4ff4d421">
+            hlineto
+            {d5a87c62} callgsubr
+            return
+        </CharString>
+        <CharString index="3" fingerprint="fb64a85a">
+            131 rlineto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="ac63e3f4">
+            271 131 hstem
+            return
+        </CharString>
+        <CharString index="1" fingerprint="58a7b0aa">
+            37 {5b68d019} callgsubr
+            -140 hlineto
+            -36 -187 rlineto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="5b68d019">
+            187 rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="406c29c7">
+            hlineto
+            -37 -189 rlineto
+            139 hlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/plus_plus.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/plus_plus.liga.xml
@@ -1,62 +1,58 @@
 <Glyph name="plus_plus.liga" lsb="-501" width="625">
     <CharString>
-        {ac63e3f4} callgsubr
+        {ac63e3f4} callsubr
         -3 525 vstem
         342 402 rmoveto
-        {58a7b0aa} callgsubr
-        -359 {f3ea7dc6} callsubr
+        {7f8bfa69} callsubr
+        -359 {9c2610c2} callgsubr
         37 189 rlineto
         359 {406c29c7} callgsubr
         37 189 rlineto
-        179 {4ff4d421} callsubr
+        179 {256033b9} callsubr
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="f3ea7dc6">
-            hlineto
-            {58a7b0aa} callgsubr
-            -179 {fdbdf28a} callsubr
-            181 {406c29c7} callgsubr
+        <CharString index="0" fingerprint="ac63e3f4">
+            271 131 hstem
             return
         </CharString>
-        <CharString index="1" fingerprint="fdbdf28a">
+        <CharString index="1" fingerprint="7f8bfa69">
+            37 187 rlineto
+            -140 hlineto
+            -36 -187 rlineto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="fdbdf28a">
             hlineto
             -27 -131 rlineto
             return
         </CharString>
-        <CharString index="2" fingerprint="4ff4d421">
+        <CharString index="3" fingerprint="256033b9">
             hlineto
-            {d5a87c62} callgsubr
+            {d5a87c62} callsubr
             return
         </CharString>
-        <CharString index="3" fingerprint="fb64a85a">
+        <CharString index="4" fingerprint="d5a87c62">
+            26 {fb64a85a} callsubr
+            return
+        </CharString>
+        <CharString index="5" fingerprint="fb64a85a">
             131 rlineto
             return
         </CharString>
     </Subrs>
     <GlobalSubrs>
-        <CharString index="0" fingerprint="ac63e3f4">
-            271 131 hstem
+        <CharString index="0" fingerprint="9c2610c2">
+            hlineto
+            {7f8bfa69} callsubr
+            -179 {fdbdf28a} callsubr
+            181 {406c29c7} callgsubr
             return
         </CharString>
-        <CharString index="1" fingerprint="58a7b0aa">
-            37 {5b68d019} callgsubr
-            -140 hlineto
-            -36 -187 rlineto
-            return
-        </CharString>
-        <CharString index="2" fingerprint="5b68d019">
-            187 rlineto
-            return
-        </CharString>
-        <CharString index="3" fingerprint="406c29c7">
+        <CharString index="1" fingerprint="406c29c7">
             hlineto
             -37 -189 rlineto
             139 hlineto
-            return
-        </CharString>
-        <CharString index="4" fingerprint="d5a87c62">
-            26 {fb64a85a} callsubr
             return
         </CharString>
     </GlobalSubrs>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/question_question.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/question_question.liga.xml
@@ -1,0 +1,53 @@
+<Glyph name="question_question.liga" lsb="-365" width="625">
+    <CharString>
+        0 168 hstem
+        -71 177 303 177 vstem
+        -293 755 rmoveto
+        {1ed82935} callsubr
+        480 hmoveto
+        {1ed82935} callsubr
+        -552 -755 {4181973e} callgsubr
+        447 -168 {4181973e} callgsubr
+        endchar
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="1ed82935">
+            -36 -156 rlineto
+            172 -18 86 -23 -61 vvcurveto
+            -50 -56 -39 -148 -77 vhcurveto
+            48 -81 rlineto
+            239 116 94 94 94 vvcurveto
+            109 -126 65 -273 27 vhcurveto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="1ed82935">
+            -36 -156 rlineto
+            172 -18 86 -23 -61 vvcurveto
+            -50 -56 -39 -148 -77 vhcurveto
+            48 -81 rlineto
+            239 116 94 94 94 vvcurveto
+            109 -126 65 -273 27 vhcurveto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="4181973e">
+            rmoveto
+            {f230a2a4} callgsubr
+            33 168 rlineto
+            -181 hlineto
+            return
+        </CharString>
+        <CharString index="1" fingerprint="f230a2a4">
+            181 hlineto
+            return
+        </CharString>
+        <CharString index="2" fingerprint="4181973e">
+            rmoveto
+            {f230a2a4} callgsubr
+            33 168 rlineto
+            -181 hlineto
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/question_question.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/question_question.liga.xml
@@ -3,43 +3,30 @@
         0 168 hstem
         -71 177 303 177 vstem
         -293 755 rmoveto
-        {1ed82935} callsubr
+        {f5650554} callsubr
         480 hmoveto
-        {1ed82935} callsubr
-        -552 -755 {4181973e} callgsubr
-        447 -168 {4181973e} callgsubr
+        {f5650554} callsubr
+        -552 -755 {4181973e} callsubr
+        447 -168 {4181973e} callsubr
         endchar
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="1ed82935">
+        <CharString index="0" fingerprint="f5650554">
             -36 -156 rlineto
             172 -18 86 -23 -61 vvcurveto
             -50 -56 -39 -148 -77 vhcurveto
-            48 -81 rlineto
-            239 116 94 94 94 vvcurveto
+            48 -81 {44dabc1d} callgsubr
+            116 94 94 94 vvcurveto
             109 -126 65 -273 27 vhcurveto
             return
         </CharString>
-        <CharString index="1" fingerprint="1ed82935">
+        <CharString index="1" fingerprint="f5650554">
             -36 -156 rlineto
             172 -18 86 -23 -61 vvcurveto
             -50 -56 -39 -148 -77 vhcurveto
-            48 -81 rlineto
-            239 116 94 94 94 vvcurveto
+            48 -81 {44dabc1d} callgsubr
+            116 94 94 94 vvcurveto
             109 -126 65 -273 27 vhcurveto
-            return
-        </CharString>
-    </Subrs>
-    <GlobalSubrs>
-        <CharString index="0" fingerprint="4181973e">
-            rmoveto
-            {f230a2a4} callgsubr
-            33 168 rlineto
-            -181 hlineto
-            return
-        </CharString>
-        <CharString index="1" fingerprint="f230a2a4">
-            181 hlineto
             return
         </CharString>
         <CharString index="2" fingerprint="4181973e">
@@ -47,6 +34,20 @@
             {f230a2a4} callgsubr
             33 168 rlineto
             -181 hlineto
+            return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="44dabc1d">
+            rlineto
+            239 return
+        </CharString>
+        <CharString index="1" fingerprint="44dabc1d">
+            rlineto
+            239 return
+        </CharString>
+        <CharString index="2" fingerprint="f230a2a4">
+            181 hlineto
             return
         </CharString>
     </GlobalSubrs>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/slash_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/slash_greater.liga.xml
@@ -1,0 +1,38 @@
+<Glyph name="slash_greater.liga" lsb="-496" width="625">
+    <CharString>
+        {4465ff65} callgsubr
+        hstemhm
+        -496 791 -232 496 hintmask 11000000
+        246 693 rmoveto
+        49 73 {8f7a5840} callsubr
+        520 781 247 -244 -2 -13 rlineto
+        hintmask 10100000
+        -344 -215 {2e3e492a} callsubr
+    </CharString>
+    <Subrs>
+        <CharString index="0" fingerprint="8f7a5840">
+            -129 50 -662 -991 138 -40 return
+        </CharString>
+        <CharString index="1" fingerprint="2e3e492a">
+            {0294fbed} callsubr
+            endchar
+        </CharString>
+        <CharString index="2" fingerprint="0294fbed">
+            {ce9611a3} callgsubr
+            rlineto
+            return
+        </CharString>
+        <CharString index="3" fingerprint="9ffb92b0">
+            63 -122 409 264 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="4465ff65">
+            -215 1031 return
+        </CharString>
+        <CharString index="1" fingerprint="ce9611a3">
+            {9ffb92b0} callsubr
+            24 130 return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/slash_greater.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/slash_greater.liga.xml
@@ -1,38 +1,37 @@
 <Glyph name="slash_greater.liga" lsb="-496" width="625">
     <CharString>
-        {4465ff65} callgsubr
+        {4465ff65} callsubr
         hstemhm
         -496 791 -232 496 hintmask 11000000
         246 693 rmoveto
         49 73 {8f7a5840} callsubr
         520 781 247 -244 -2 -13 rlineto
         hintmask 10100000
-        -344 -215 {2e3e492a} callsubr
+        -344 -215 {9d6990a4} callsubr
     </CharString>
     <Subrs>
-        <CharString index="0" fingerprint="8f7a5840">
-            -129 50 -662 -991 138 -40 return
-        </CharString>
-        <CharString index="1" fingerprint="2e3e492a">
-            {0294fbed} callsubr
-            endchar
-        </CharString>
-        <CharString index="2" fingerprint="0294fbed">
-            {ce9611a3} callgsubr
-            rlineto
-            return
-        </CharString>
-        <CharString index="3" fingerprint="9ffb92b0">
-            63 -122 409 264 return
-        </CharString>
-    </Subrs>
-    <GlobalSubrs>
         <CharString index="0" fingerprint="4465ff65">
             -215 1031 return
         </CharString>
-        <CharString index="1" fingerprint="ce9611a3">
+        <CharString index="1" fingerprint="8f7a5840">
+            -129 50 -662 -991 138 -40 return
+        </CharString>
+        <CharString index="2" fingerprint="9d6990a4">
+            {0a376d15} callsubr
+            endchar
+        </CharString>
+        <CharString index="3" fingerprint="0a376d15">
+            {ce9611a3} callsubr
+            rlineto
+            return
+        </CharString>
+        <CharString index="4" fingerprint="ce9611a3">
             {9ffb92b0} callsubr
             24 130 return
         </CharString>
-    </GlobalSubrs>
+        <CharString index="5" fingerprint="9ffb92b0">
+            63 -122 409 264 return
+        </CharString>
+    </Subrs>
+    <GlobalSubrs/>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/underscore_underscore.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/underscore_underscore.liga.xml
@@ -1,0 +1,18 @@
+<Glyph name="underscore_underscore.liga" lsb="-707" width="625">
+    <CharString>
+        {aac958d4} callgsubr
+        -707 1281 vstem
+        574 -57 rmoveto
+        -1259 hlineto
+        -22 -117 rlineto
+        1259 hlineto
+        endchar
+    </CharString>
+    <Subrs/>
+    <GlobalSubrs>
+        <CharString index="0" fingerprint="aac958d4">
+            -174 117 hstem
+            return
+        </CharString>
+    </GlobalSubrs>
+</Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/uniE0A0.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/uniE0A0.xml
@@ -28,26 +28,26 @@
         71 -57 57 -71 vhcurveto
         hintmask 1110110110100000
         -384 63 rmoveto
-        35 29 -29 -35 -35 -29 -29 -35 {0f5e6060} callgsubr
+        35 29 -29 -35 -35 -29 -29 -35 {0f5e6060} callsubr
         hvcurveto
         384 -256 rmoveto
         hintmask 1101101010100000
-        {0f5e6060} callgsubr
+        {0f5e6060} callsubr
         35 29 -29 -35 hvcurveto
         hintmask 1110110110100000
         -35 -29 -29 -35 vhcurveto
         -384 -512 rmoveto
-        {0f5e6060} callgsubr
+        {0f5e6060} callsubr
         35 29 -29 -35 -35 -29 -29 -35 hvcurveto
         endchar
     </CharString>
-    <Subrs/>
-    <GlobalSubrs>
+    <Subrs>
         <CharString index="0" fingerprint="0f5e6060">
             -35 -29 29 35 35 29 29 35 return
         </CharString>
         <CharString index="1" fingerprint="0f5e6060">
             -35 -29 29 35 35 29 29 35 return
         </CharString>
-    </GlobalSubrs>
+    </Subrs>
+    <GlobalSubrs/>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/uniE0B0.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/uniE0B0.xml
@@ -1,16 +1,16 @@
 <Glyph name="uniE0B0" code="0xe0b0" lsb="-20" width="625">
     <CharString>
-        {f3a6bced} callgsubr
+        {f3a6bced} callsubr
         672 365 rmoveto
         -690 639 -2 -1209 rlineto
         endchar
     </CharString>
-    <Subrs/>
-    <GlobalSubrs>
+    <Subrs>
         <CharString index="0" fingerprint="f3a6bced">
             -205 1209 hstem
             -20 692 vstem
             return
         </CharString>
-    </GlobalSubrs>
+    </Subrs>
+    <GlobalSubrs/>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/uniE0B0.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/uniE0B0.xml
@@ -1,16 +1,16 @@
 <Glyph name="uniE0B0" code="0xe0b0" lsb="-20" width="625">
     <CharString>
-        {f3a6bced} callsubr
+        {f3a6bced} callgsubr
         672 365 rmoveto
         -690 639 -2 -1209 rlineto
         endchar
     </CharString>
-    <Subrs>
+    <Subrs/>
+    <GlobalSubrs>
         <CharString index="0" fingerprint="f3a6bced">
             -205 1209 hstem
             -20 692 vstem
             return
         </CharString>
-    </Subrs>
-    <GlobalSubrs/>
+    </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/uniE0B2.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/uniE0B2.xml
@@ -1,16 +1,16 @@
 <Glyph name="uniE0B2" code="0xe0b2" lsb="-20" width="625">
     <CharString>
-        {f3a6bced} callsubr
+        {f3a6bced} callgsubr
         -20 365 rmoveto
         692 -570 -2 1209 rlineto
         endchar
     </CharString>
-    <Subrs>
+    <Subrs/>
+    <GlobalSubrs>
         <CharString index="0" fingerprint="f3a6bced">
             -205 1209 hstem
             -20 692 vstem
             return
         </CharString>
-    </Subrs>
-    <GlobalSubrs/>
+    </GlobalSubrs>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/uniE0B2.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/glyphs/uniE0B2.xml
@@ -1,16 +1,16 @@
 <Glyph name="uniE0B2" code="0xe0b2" lsb="-20" width="625">
     <CharString>
-        {f3a6bced} callgsubr
+        {f3a6bced} callsubr
         -20 365 rmoveto
         692 -570 -2 1209 rlineto
         endchar
     </CharString>
-    <Subrs/>
-    <GlobalSubrs>
+    <Subrs>
         <CharString index="0" fingerprint="f3a6bced">
             -205 1209 hstem
             -20 692 vstem
             return
         </CharString>
-    </GlobalSubrs>
+    </Subrs>
+    <GlobalSubrs/>
 </Glyph>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/gsubrs.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/gsubrs.xml
@@ -130,7 +130,7 @@
     <CharString index="9">
         
         -67 callgsubr
-        -34 callgsubr
+        -34 callsubr
         vhcurveto
         -81 callsubr
         return
@@ -268,8 +268,8 @@
     <CharString index="21">
         
         rmoveto
-        25 -97 rlineto
-        239 54 89 127 129 vvcurveto
+        25 -97 86 callgsubr
+        54 89 127 129 vvcurveto
         102 -68 53 -99 -109 -84 -67 -98 -105 113 -44 115 67 vhcurveto
         -27 -51 -61 -48 -133 -22 rrcurveto
         105 216 rmoveto
@@ -321,7 +321,7 @@
         hintmask 10100000
         -78 callgsubr
         hintmask 11000000
-        -34 callsubr
+        -34 callgsubr
         return
       
     </CharString>
@@ -392,7 +392,7 @@
       
     <CharString index="32">
         
-        246 74 callgsubr
+        246 74 callsubr
         79 130 vvcurveto
         91 -66 56 -105 -197 -157 -195 -181 return
       
@@ -413,7 +413,7 @@
     <CharString index="34">
         
         rmoveto
-        9 callsubr
+        9 callgsubr
         -232 158 -97 299 98 hvcurveto
         16 140 rlineto
         -68 callsubr
@@ -427,10 +427,10 @@
         rmoveto
         122 -394 rlineto
         132 hlineto
-        134 688 81 callsubr
+        134 688 83 callgsubr
         -72 -394 rlineto
         -4 hlineto
-        -111 396 -144 -4 -134 -686 40 callgsubr
+        -111 396 -144 -4 -134 -686 39 callsubr
         71 394 rlineto
         return
       
@@ -466,7 +466,7 @@
     <CharString index="39">
         
         rmoveto
-        -13 73 85 callsubr
+        -13 73 86 callsubr
         -42 -39 14 80 vvcurveto
         19 vlineto
         187 30 68 100 101 vvcurveto
@@ -581,7 +581,7 @@
       
     <CharString index="48">
         
-        -7 8 -8 133 166 109 163 45 callgsubr
+        -7 8 -8 133 166 109 163 45 callsubr
         hintmask 01111000
         53 callsubr
         -55 -283 rlineto
@@ -589,14 +589,14 @@
         -21 -109 rlineto
         61 hlineto
         hintmask 10111000
-        -56 -291 3 callgsubr
+        -56 -291 3 callsubr
         -353 -141 rmoveto
         93 hlineto
         28 109 rlineto
-        -100 90 callsubr
+        -100 92 callgsubr
         98 7 43 -52 -102 vvcurveto
         hintmask 01111000
-        20 callsubr
+        20 callgsubr
         endchar
       
     </CharString>
@@ -623,10 +623,9 @@
       
     <CharString index="51">
         
-        454 hlineto
-        36 135 -284 -5 332 304 26 129 rlineto
-        -445 hlineto
-        -37 -136 277 6 -334 -304 rlineto
+        484 hlineto
+        27 140 -301 -3 376 417 22 134 74 callgsubr
+        -140 298 4 -381 -418 rlineto
         endchar
       
     </CharString>
@@ -644,7 +643,7 @@
     <CharString index="53">
         
         38 callsubr
-        122 631 -152 -11 -38 -197 0 callgsubr
+        122 631 -152 -11 -38 -197 1 callgsubr
         hintmask 10111000
         -60 callsubr
       
@@ -687,7 +686,7 @@
         -32 -167 rlineto
         288 hlineto
         32 129 rlineto
-        -165 90 callsubr
+        -165 92 callgsubr
         124 hlineto
         22 106 rlineto
         -125 hlineto
@@ -735,7 +734,7 @@
       
     <CharString index="61">
         
-        15 callsubr
+        16 callgsubr
         529 59 -65 callsubr
         return
       
@@ -798,8 +797,8 @@
       
     <CharString index="69">
         
-        -17 callgsubr
-        -31 callgsubr
+        -24 callgsubr
+        -36 callgsubr
         return
       
     </CharString>
@@ -807,8 +806,8 @@
       
     <CharString index="70">
         
-        -16 callgsubr
-        -31 callsubr
+        -17 callgsubr
+        -31 callgsubr
         return
       
     </CharString>
@@ -825,17 +824,15 @@
       
     <CharString index="72">
         
-        -47 callsubr
-        hstem
-        return
+        -13 131 87 82 168 124 return
       
     </CharString>
     
       
     <CharString index="73">
         
-        -11 callgsubr
-        -17 1 -15 1 -15 return
+        -75 -61 -158 -84 -11 callgsubr
+        return
       
     </CharString>
     
@@ -861,7 +858,7 @@
     <CharString index="76">
         
         hstem
-        48 157 217 71 callgsubr
+        55 167 221 168 vstem
         return
       
     </CharString>
@@ -893,7 +890,9 @@
       
     <CharString index="79">
         
-        113 -52 111 74 110 return
+        -2 vhcurveto
+        150 2 rlineto
+        189 return
       
     </CharString>
     
@@ -925,7 +924,7 @@
         182 hlineto
         27 135 rlineto
         -525 hlineto
-        -27 -135 93 callgsubr
+        -27 -135 93 callsubr
         -106 -553 rlineto
         return
       
@@ -950,7 +949,7 @@
       
     <CharString index="85">
         
-        -189 141 89 135 1 callgsubr
+        -189 141 89 135 1 callsubr
         return
       
     </CharString>
@@ -985,7 +984,9 @@
       
     <CharString index="88">
         
-        -16 147 -37 callsubr
+        151 hstem
+        124 12 callgsubr
+        vstem
         return
       
     </CharString>
@@ -993,29 +994,31 @@
       
     <CharString index="89">
         
-        -17 callsubr
-        24 130 return
+        454 hlineto
+        26 135 rlineto
+        -292 hlineto
+        return
       
     </CharString>
     
       
     <CharString index="90">
         
-        -16 127 342 126 return
+        -14 136 443 137 return
       
     </CharString>
     
       
     <CharString index="91">
         
-        -14 136 443 137 return
+        -16 127 342 126 return
       
     </CharString>
     
       
     <CharString index="92">
         
-        -20 callsubr
+        -19 callsubr
         -80 153 return
       
     </CharString>
@@ -1023,9 +1026,10 @@
       
     <CharString index="93">
         
-        -107 -1322 380 hstem
-        -849 400 vstem
-        -449 -291 -90 callsubr
+        623 251 hstem
+        155 363 vstem
+        155 -44 callgsubr
+        endchar
       
     </CharString>
     
@@ -1048,7 +1052,9 @@
       
     <CharString index="96">
         
-        -177 -186 -247 -306 return
+        vvcurveto
+        -91 84 -24 159 99 vhcurveto
+        return
       
     </CharString>
     
@@ -1065,7 +1071,7 @@
       
     <CharString index="98">
         
-        -12 133 314 129 return
+        0 125 438 125 return
       
     </CharString>
     
@@ -1100,7 +1106,7 @@
     <CharString index="101">
         
         hstemhm
-        58 -28 callgsubr
+        58 -28 callsubr
         return
       
     </CharString>
@@ -1108,8 +1114,9 @@
       
     <CharString index="102">
         
-        144 346 vstem
-        459 619 -95 callsubr
+        615 243 hstem
+        134 435 vstem
+        311 615 -82 callsubr
         endchar
       
     </CharString>
@@ -1118,7 +1125,7 @@
     <CharString index="103">
         
         69 rlineto
-        -102 12 callsubr
+        -102 13 callgsubr
         return
       
     </CharString>
@@ -1126,9 +1133,8 @@
       
     <CharString index="104">
         
-        111 435 vstem
-        336 725 -88 callsubr
-        endchar
+        27 132 rlineto
+        return
       
     </CharString>
     
@@ -1138,7 +1144,7 @@
         rmoveto
         191 977 rlineto
         -362 hlineto
-        -25 -122 93 callsubr
+        -25 -122 94 callgsubr
         -141 -733 rlineto
         -207 hlineto
         -24 -122 rlineto
@@ -1149,14 +1155,22 @@
       
     <CharString index="106">
         
-        -13 131 82 callgsubr
-        19 callsubr
+        -15 144 433 141 21 callgsubr
         return
       
     </CharString>
     
       
     <CharString index="107">
+        
+        -13 131 81 callgsubr
+        19 callgsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="108">
         
         rlineto
         2 -14 -13 0 -12 hhcurveto
@@ -1166,18 +1180,10 @@
     </CharString>
     
       
-    <CharString index="108">
-        
-        hstem
-        65 155 161 132 vstem
-        return
-      
-    </CharString>
-    
-      
     <CharString index="109">
         
-        27 132 rlineto
+        hstem
+        178 95 callgsubr
         return
       
     </CharString>
@@ -1185,8 +1191,10 @@
       
     <CharString index="110">
         
-        rlineto
-        418 -53 149 235 250 vvcurveto
+        hlineto
+        31 callsubr
+        -179 -22 callsubr
+        181 57 callgsubr
         return
       
     </CharString>
@@ -1194,7 +1202,7 @@
       
     <CharString index="111">
         
-        146 hlineto
+        98 180 95 hstem
         return
       
     </CharString>
@@ -1202,8 +1210,10 @@
       
     <CharString index="112">
         
-        26 46 callsubr
-        return
+        657 128 hstem
+        114 426 vstem
+        515 657 -64 callgsubr
+        endchar
       
     </CharString>
     
@@ -1236,8 +1246,7 @@
       
     <CharString index="116">
         
-        -14 136 34 callsubr
-        return
+        -197 -162 -213 -236 return
       
     </CharString>
     
@@ -1252,9 +1261,7 @@
       
     <CharString index="118">
         
-        hstem
-        35 callsubr
-        vstem
+        115 -25 115 hstemhm
         return
       
     </CharString>
@@ -1269,8 +1276,7 @@
       
     <CharString index="120">
         
-        rlineto
-        -145 hlineto
+        -29 -40 15 32 vvcurveto
         return
       
     </CharString>
@@ -1278,18 +1284,15 @@
       
     <CharString index="121">
         
-        rmoveto
-        87 -121 289 225 38 154 -206 240 -111 -105 180 -201 rlineto
-        endchar
+        -14 24 121 -145 14 38 154 -148 13 -34 -153 -161 15 -25 -122 158 -15 return
       
     </CharString>
     
       
     <CharString index="122">
         
-        40 24 53 60 60 vhcurveto
-        16 callgsubr
-        -29 -17 16 38 hvcurveto
+        -7 127 331 118 -117 122 hstemhm
+        16 158 76 144 114 141 hintmask 11011100
         return
       
     </CharString>
@@ -1297,8 +1300,8 @@
       
     <CharString index="123">
         
-        18 -48 24 -51 30 -53 rrcurveto
-        -40 -44 -38 -15 -28 hhcurveto
+        -16 132 324 118 hstem
+        146 156 vstem
         return
       
     </CharString>
@@ -1306,25 +1309,14 @@
       
     <CharString index="124">
         
-        55 -62 63 38 vvcurveto
-        45 79 31 184 31 vhcurveto
-        -28 127 rlineto
-        -294 -70 -88 -92 -84 vvcurveto
-        return
+        -140 -179 -135 -175 -236 vhcurveto
+        87 14 rmoveto
+        183 94 136 123 90 69 return
       
     </CharString>
     
       
     <CharString index="125">
-        
-        -14 120 hstem
-        294 160 vstem
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="126">
         
         hstem
         61 161 218 150 vstem
@@ -1333,19 +1325,27 @@
     </CharString>
     
       
+    <CharString index="126">
+        
+        hstem
+        59 154 217 140 vstem
+        return
+      
+    </CharString>
+    
+      
     <CharString index="127">
         
-        -9 callsubr
-        hstem
-        28 return
+        -155 -77 -142 -149 6 vhcurveto
+        return
       
     </CharString>
     
       
     <CharString index="128">
         
-        hlineto
-        2 callgsubr
+        hstem
+        63 159 227 150 vstem
         return
       
     </CharString>
@@ -1361,16 +1361,14 @@
       
     <CharString index="130">
         
-        20 callgsubr
-        583 vstem
-        return
+        -4 -2 -3 -8 -9 2 -3 4 4 2 3 9 return
       
     </CharString>
     
       
     <CharString index="131">
         
-        95 86 3 callsubr
+        112 134 114 vstem
         return
       
     </CharString>
@@ -1378,7 +1376,7 @@
       
     <CharString index="132">
         
-        112 134 114 vstem
+        120 160 66 callgsubr
         return
       
     </CharString>
@@ -1394,8 +1392,8 @@
       
     <CharString index="134">
         
-        31 callsubr
-        57 callsubr
+        32 callgsubr
+        56 callsubr
         hintmask 01111000
         return
       
@@ -1404,16 +1402,33 @@
       
     <CharString index="135">
         
-        hhcurveto
-        55 1 -64 -75 -42 hvcurveto
-        65 -23 rlineto
-        164 132 -8 162 -140 hhcurveto
+        vstem
+        55 hmoveto
+        -41 callsubr
         return
       
     </CharString>
     
       
     <CharString index="136">
+        
+        -3 callgsubr
+        -519 -11 callsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="137">
+        
+        2 callsubr
+        -518 -22 callsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="138">
         
         vstem
         6 callsubr
@@ -1423,39 +1438,16 @@
     </CharString>
     
       
-    <CharString index="137">
-        
-        37 94 callgsubr
-        -140 hlineto
-        -36 -187 rlineto
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="138">
-        
-        26 134 rlineto
-        -339 63 callgsubr
-        return
-      
-    </CharString>
-    
-      
     <CharString index="139">
         
-        rmoveto
-        84 callgsubr
-        33 168 rlineto
-        -181 hlineto
-        return
+        -14 144 -142 128 335 127 return
       
     </CharString>
     
       
     <CharString index="140">
         
-        -244 39 callsubr
+        -244 40 callgsubr
         72 95 return
       
     </CharString>
@@ -1472,7 +1464,8 @@
       
     <CharString index="142">
         
-        100 240 105 hstem
+        hstem
+        68 95 callgsubr
         return
       
     </CharString>
@@ -1499,8 +1492,8 @@
       
     <CharString index="145">
         
-        4 callgsubr
-        44 194 13 callgsubr
+        4 callsubr
+        44 194 13 callsubr
         return
       
     </CharString>
@@ -1516,17 +1509,14 @@
       
     <CharString index="147">
         
-        rlineto
-        150 hlineto
-        return
+        88 280 95 return
       
     </CharString>
     
       
     <CharString index="148">
         
-        94 callsubr
-        523 -19 callsubr
+        164 rlineto
         return
       
     </CharString>
@@ -1552,22 +1542,23 @@
       
     <CharString index="151">
         
-        0 139 411 138 return
+        122 733 122 hstem
+        return
       
     </CharString>
     
       
     <CharString index="152">
         
-        132 hstemhm
-        441 159 return
+        0 139 411 138 return
       
     </CharString>
     
       
     <CharString index="153">
         
-        269 134 hstem
+        rmoveto
+        2 callsubr
         return
       
     </CharString>
@@ -1575,7 +1566,7 @@
       
     <CharString index="154">
         
-        -7 8 -8 133 438 45 callgsubr
+        -7 8 -8 133 438 45 callsubr
         hintmask 01110000
         return
       
@@ -1621,7 +1612,7 @@
     <CharString index="159">
         
         164 hstem
-        77 152 145 98 34 83 callgsubr
+        77 152 145 98 34 83 callsubr
         472 return
       
     </CharString>
@@ -1659,6 +1650,15 @@
       
     <CharString index="163">
         
+        vvcurveto
+        -81 102 -51 194 91 vhcurveto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="164">
+        
         hlineto
         -37 -189 rlineto
         139 hlineto
@@ -1667,31 +1667,25 @@
     </CharString>
     
       
-    <CharString index="164">
+    <CharString index="165">
         
         -9 -7 -7 -9 -9 -7 6 10 return
       
     </CharString>
     
       
-    <CharString index="165">
-        
-        -35 -29 29 35 35 29 29 35 return
-      
-    </CharString>
-    
-      
     <CharString index="166">
         
-        39 callgsubr
-        85 95 return
+        24 130 rlineto
+        -152 -57 rmoveto
+        return
       
     </CharString>
     
       
     <CharString index="167">
         
-        hintmask 1100010001001000111100010001010000101100
+        hintmask 1000010001001000111100010001000010011100
         return
       
     </CharString>
@@ -1699,7 +1693,7 @@
       
     <CharString index="168">
         
-        hintmask 1000010001010000111100010000100010101100
+        hintmask 1100010001001000111100010001010000101100
         return
       
     </CharString>
@@ -1707,7 +1701,7 @@
       
     <CharString index="169">
         
-        99 263 99 hstem
+        88 119 73 hstem
         return
       
     </CharString>
@@ -1715,8 +1709,7 @@
       
     <CharString index="170">
         
-        hlineto
-        -27 -134 rlineto
+        99 263 99 hstem
         return
       
     </CharString>
@@ -1724,10 +1717,8 @@
       
     <CharString index="171">
         
-        vstem
-        229 346 rmoveto
-        189 hlineto
-        34 94 callgsubr
+        586 51 81 callsubr
+        10 callsubr
         return
       
     </CharString>
@@ -1735,9 +1726,10 @@
       
     <CharString index="172">
         
-        rmoveto
-        1723 21 callgsubr
-        -1723 hlineto
+        vstem
+        229 346 rmoveto
+        189 hlineto
+        34 187 rlineto
         return
       
     </CharString>
@@ -1745,7 +1737,7 @@
       
     <CharString index="173">
         
-        153 hstem
+        118 vstem
         return
       
     </CharString>
@@ -1753,7 +1745,7 @@
       
     <CharString index="174">
         
-        118 vstem
+        153 hstem
         return
       
     </CharString>
@@ -1761,17 +1753,14 @@
       
     <CharString index="175">
         
-        -344 -215 63 -122 279 180 rlineto
-        return
+        157 -46 147 -128 150 -101 141 return
       
     </CharString>
     
       
     <CharString index="176">
         
-        62 123 36 83 vvcurveto
-        39 -25 36 -73 27 vhcurveto
-        return
+        141 -101 150 -128 147 -46 157 return
       
     </CharString>
     
@@ -1779,7 +1768,7 @@
     <CharString index="177">
         
         -243 rmoveto
-        2 callgsubr
+        -3 callgsubr
         return
       
     </CharString>
@@ -1795,8 +1784,9 @@
       
     <CharString index="179">
         
-        92 callgsubr
-        -27 return
+        26 callsubr
+        hstem
+        return
       
     </CharString>
     
@@ -1811,12 +1801,20 @@
       
     <CharString index="181">
         
-        18 130 return
+        93 callgsubr
+        -27 return
       
     </CharString>
     
       
     <CharString index="182">
+        
+        -83 89 -123 -188 -141 -213 return
+      
+    </CharString>
+    
+      
+    <CharString index="183">
         
         -91 50 -61 97 69 73 31 66 76 vhcurveto
         return
@@ -1824,16 +1822,10 @@
     </CharString>
     
       
-    <CharString index="183">
-        
-        -83 89 -123 -188 -141 -213 return
-      
-    </CharString>
-    
-      
     <CharString index="184">
         
-        hintmask 1000010001001000111010010001000010101100
+        -205 1209 hstem
+        -20 692 vstem
         return
       
     </CharString>
@@ -1841,7 +1833,7 @@
       
     <CharString index="185">
         
-        hintmask 1000010001000100111100010011000010101100
+        hintmask 1000010001010000111100010001000010101100
         return
       
     </CharString>
@@ -1857,8 +1849,7 @@
       
     <CharString index="187">
         
-        hhcurveto
-        hintmask 10100000
+        hintmask 1000010001001000111010010001000010101100
         return
       
     </CharString>
@@ -1866,21 +1857,23 @@
       
     <CharString index="188">
         
-        -215 1031 return
+        329 131 return
       
     </CharString>
     
       
     <CharString index="189">
         
-        329 131 return
+        81 67 callgsubr
+        return
       
     </CharString>
     
       
     <CharString index="190">
         
-        130 vstem
+        86 callsubr
+        hlineto
         return
       
     </CharString>
@@ -1896,25 +1889,24 @@
       
     <CharString index="192">
         
-        142 rlinecurve
-        -184 -4 3 -121 return
+        6 -1 3 -4 -3 -2 -2 -7 vhcurveto
+        return
       
     </CharString>
     
       
     <CharString index="193">
         
-        rmoveto
-        -12 76 return
+        rlineto
+        239 return
       
     </CharString>
     
       
     <CharString index="194">
         
-        vvcurveto
-        -81 102 -51 193 91 vhcurveto
-        return
+        rmoveto
+        -12 76 return
       
     </CharString>
     
@@ -1930,7 +1922,8 @@
       
     <CharString index="196">
         
-        -174 117 hstem
+        hlineto
+        74 -73 -2 -13 -40 -25 rlineto
         return
       
     </CharString>
@@ -1938,16 +1931,15 @@
       
     <CharString index="197">
         
-        hlineto
-        -74 -111 rlineto
-        return
+        rmoveto
+        131 3 6 return
       
     </CharString>
     
       
     <CharString index="198">
         
-        271 131 hstem
+        -174 117 hstem
         return
       
     </CharString>
@@ -1955,8 +1947,8 @@
       
     <CharString index="199">
         
-        rlineto
-        -473 hlineto
+        hlineto
+        32 163 rlineto
         return
       
     </CharString>
@@ -1965,7 +1957,7 @@
     <CharString index="200">
         
         rlineto
-        84 callgsubr
+        -473 hlineto
         return
       
     </CharString>
@@ -1973,7 +1965,8 @@
       
     <CharString index="201">
         
-        187 rlineto
+        rlineto
+        207 hlineto
         return
       
     </CharString>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/gsubrs.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/gsubrs.xml
@@ -18,7 +18,7 @@
     <CharString index="1">
         
         rmoveto
-        159 12 -48 callsubr
+        159 12 -45 callgsubr
         rlinecurve
         -86 callsubr
         1 -58 1 -58 2 -57 rrcurveto
@@ -59,8 +59,8 @@
     <CharString index="4">
         
         rmoveto
-        145 -86 88 -135 -42 callgsubr
-        -145 86 -89 135 -43 callsubr
+        145 -86 88 -135 -40 callsubr
+        -145 86 -89 135 -40 callgsubr
         vhcurveto
         -374 -110 rmoveto
         108 53 109 80 51 33 -45 -81 -107 -53 -109 -80 -51 -33 44 81 vhcurveto
@@ -130,9 +130,9 @@
     <CharString index="9">
         
         -67 callgsubr
-        -38 callsubr
+        -34 callgsubr
         vhcurveto
-        -80 callgsubr
+        -81 callsubr
         return
       
     </CharString>
@@ -220,8 +220,8 @@
     <CharString index="17">
         
         rmoveto
-        -81 callgsubr
-        -51 -185 97 -73 317 139 rlinecurve
+        -89 callsubr
+        451 hlineto
         endchar
       
     </CharString>
@@ -230,8 +230,7 @@
     <CharString index="18">
         
         337 hlineto
-        21 100 rlineto
-        -180 hlineto
+        21 100 50 callgsubr
         134 80 74 64 79 vvcurveto
         94 -105 50 -204 -31 vhcurveto
         -14 -103 rlineto
@@ -260,7 +259,7 @@
         -88 -455 rlineto
         -80 -15 -34 -31 -49 hhcurveto
         -44 -38 25 119 24 hvcurveto
-        81 422 -15 callgsubr
+        81 422 -8 callgsubr
         -79 -407 return
       
     </CharString>
@@ -318,11 +317,11 @@
       
     <CharString index="25">
         
-        2 callsubr
+        10 callsubr
         hintmask 10100000
         -78 callgsubr
         hintmask 11000000
-        -37 callgsubr
+        -34 callsubr
         return
       
     </CharString>
@@ -340,10 +339,12 @@
       
     <CharString index="27">
         
-        -76 -48 36 -60 55 32 49 -144 146 -18 213 121 rlinecurve
-        -119 566 rmoveto
-        21 18 -15 -36 -70 -61 -109 -128 -119 hvcurveto
-        213 6 79 136 65 hhcurveto
+        rmoveto
+        67 -51 74 53 91 86 53 60 rlinecurve
+        -140 74 -34 -64 -63 -96 -48 -62 rlinecurve
+        240 -1 rmoveto
+        68 -51 74 53 88 84 52 61 rlinecurve
+        -144 65 -33 -64 -57 -87 -48 -61 rlinecurve
         return
       
     </CharString>
@@ -360,12 +361,12 @@
       
     <CharString index="29">
         
-        -29 callsubr
+        -25 callsubr
         -65 -66 -36 -67 -66 vhcurveto
         12 92 -151 -9 -22 -165 -25 -127 -51 -266 rlinecurve
         149 hlineto
         74 368 rlineto
-        41 44 37 -12 callsubr
+        41 44 37 -4 callsubr
         return
       
     </CharString>
@@ -375,7 +376,7 @@
         
         rmoveto
         -70 callsubr
-        361 -70 143 120 116 -43 callgsubr
+        361 -70 143 120 116 -41 callgsubr
         return
       
     </CharString>
@@ -391,7 +392,7 @@
       
     <CharString index="32">
         
-        246 52 callgsubr
+        246 74 callgsubr
         79 130 vvcurveto
         91 -66 56 -105 -197 -157 -195 -181 return
       
@@ -412,10 +413,10 @@
     <CharString index="34">
         
         rmoveto
-        -50 callgsubr
-        -175 139 -121 331 147 hvcurveto
-        -11 80 rlineto
-        -47 callgsubr
+        9 callsubr
+        -232 158 -97 299 98 hvcurveto
+        16 140 rlineto
+        -68 callsubr
         endchar
       
     </CharString>
@@ -426,10 +427,10 @@
         rmoveto
         122 -394 rlineto
         132 hlineto
-        134 688 48 callsubr
+        134 688 81 callsubr
         -72 -394 rlineto
         -4 hlineto
-        -111 396 -144 -4 -134 -686 24 callsubr
+        -111 396 -144 -4 -134 -686 40 callgsubr
         71 394 rlineto
         return
       
@@ -465,7 +466,7 @@
     <CharString index="39">
         
         rmoveto
-        -13 73 61 callgsubr
+        -13 73 85 callsubr
         -42 -39 14 80 vvcurveto
         19 vlineto
         187 30 68 100 101 vvcurveto
@@ -531,7 +532,7 @@
       
     <CharString index="44">
         
-        -53 callsubr
+        -51 callgsubr
         54 37 25 28 18 hhcurveto
         return
       
@@ -557,12 +558,22 @@
       
     <CharString index="47">
         
-        -125 55 -61 66 58 69 47 59 60 vhcurveto
-        -5 -112 55 -35 192 108 rrcurveto
-        -344 77 rmoveto
-        -29 -23 25 63 101 62 132 65 18 31 -5 -11 34 hvcurveto
-        -47 -244 rlineto
-        -35 -39 -43 -26 -29 hhcurveto
+        rmoveto
+        189 136 201 243 69 -12 55 -22 43 hvcurveto
+        67 93 -90 57 -49 -71 rlineto
+        20 -34 -41 10 -45 hhcurveto
+        -189 -135 -201 -243 -68 11 -54 21 -42 hvcurveto
+        -69 -96 89 -57 52 72 rlineto
+        -21 34 41 -10 46 hhcurveto
+        81 587 rmoveto
+        24 19 -11 -21 13 hvcurveto
+        -197 -280 rlineto
+        157 54 155 87 vhcurveto
+        -63 -453 rmoveto
+        -25 -20 11 24 -13 hvcurveto
+        199 281 rlineto
+        -1 vlineto
+        -161 -53 -154 -88 vhcurveto
         endchar
       
     </CharString>
@@ -570,18 +581,30 @@
       
     <CharString index="48">
         
-        -25 callsubr
-        549 69 -98 callgsubr
-        return
+        -7 8 -8 133 166 109 163 45 callgsubr
+        hintmask 01111000
+        53 callsubr
+        -55 -283 rlineto
+        -61 hlineto
+        -21 -109 rlineto
+        61 hlineto
+        hintmask 10111000
+        -56 -291 3 callgsubr
+        -353 -141 rmoveto
+        93 hlineto
+        28 109 rlineto
+        -100 90 callsubr
+        98 7 43 -52 -102 vvcurveto
+        hintmask 01111000
+        20 callsubr
+        endchar
       
     </CharString>
     
       
     <CharString index="49">
         
-        rmoveto
-        -164 -6 -2 -90 -11 -83 -27 -89 rlinecurve
-        64 -23 72 86 49 87 19 118 rlinecurve
+        916 -102 callgsubr
         return
       
     </CharString>
@@ -589,8 +612,11 @@
       
     <CharString index="50">
         
-        -65 callgsubr
-        -57 -990 -106 callgsubr
+        -24 callsubr
+        586 51 rmoveto
+        -12 76 rlineto
+        -82 callgsubr
+        return
       
     </CharString>
     
@@ -608,7 +634,8 @@
       
     <CharString index="52">
         
-        -157 -102 -106 106 -104 -79 rlineto
+        rmoveto
+        169 1 50 153 -182 -1 rlineto
         return
       
     </CharString>
@@ -616,8 +643,10 @@
       
     <CharString index="53">
         
-        744 -95 callsubr
-        return
+        38 callsubr
+        122 631 -152 -11 -38 -197 0 callgsubr
+        hintmask 10111000
+        -60 callsubr
       
     </CharString>
     
@@ -625,9 +654,9 @@
     <CharString index="54">
         
         rmoveto
-        hintmask 11011100
+        hintmask 01100000
         -63 callgsubr
-        hintmask 11101100
+        hintmask 10100000
         -69 callsubr
         return
       
@@ -636,31 +665,59 @@
       
     <CharString index="55">
         
-        438 140 hstemhm
-        37 567 -167 167 hintmask 11000000
-        257 215 rmoveto
-        146 -225 172 20 -150 215 rlineto
-        128 96 51 84 69 vvcurveto
-        63 -41 41 -71 -68 -72 -37 -73 -73 vhcurveto
-        61 316 -153 -11 -150 -773 rlineto
-        151 hlineto
-        67 347 rlineto
-        55 52 48 36 43 57 callgsubr
-        25 14 -12 -22 -38 -40 -60 -140 -91 hvcurveto
-        return
+        -52 callsubr
+        107 103 return
       
     </CharString>
     
       
     <CharString index="56">
         
-        850 -88 callsubr
+        -33 -48 90 -72 hhcurveto
+        -62 -69 -67 -87 -53 hvcurveto
+        74 -43 rlineto
         return
       
     </CharString>
     
       
     <CharString index="57">
+        
+        rmoveto
+        -32 -167 rlineto
+        288 hlineto
+        32 129 rlineto
+        -165 90 callsubr
+        124 hlineto
+        22 106 rlineto
+        -125 hlineto
+        31 161 rlineto
+        159 hlineto
+        26 129 rlineto
+        -392 hlineto
+        -109 -228 -111 -231 -106 -229 rrcurveto
+        154 hlineto
+        72 167 rlineto
+        164 392 rmoveto
+        12 hlineto
+        -54 -280 rlineto
+        -75 hlineto
+        40 94 39 94 38 92 rrcurveto
+        endchar
+      
+    </CharString>
+    
+      
+    <CharString index="58">
+        
+        -84 callsubr
+        hintmask 1111110110000000
+        -98 callsubr
+      
+    </CharString>
+    
+      
+    <CharString index="59">
         
         140 2 rlineto
         160 13 -53 62 -119 hhcurveto
@@ -669,35 +726,17 @@
     </CharString>
     
       
-    <CharString index="58">
+    <CharString index="60">
         
         133 153 116 153 133 return
       
     </CharString>
     
       
-    <CharString index="59">
-        
-        10 callsubr
-        -501 -74 callgsubr
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="60">
-        
-        -253 -36 -52 26 111 vvcurveto
-        112 67 101 87 47 17 -27 -66 -1 vhcurveto
-        return
-      
-    </CharString>
-    
-      
     <CharString index="61">
         
-        -39 callsubr
-        -34 callgsubr
+        15 callsubr
+        529 59 -65 callsubr
         return
       
     </CharString>
@@ -705,34 +744,36 @@
       
     <CharString index="62">
         
-        632 1 callsubr
-        84 491 hintmask 10100000
-        421 747 -54 callsubr
-        endchar
+        -12 230 -14 227 -15 225 return
       
     </CharString>
     
       
     <CharString index="63">
         
-        51 130 32 102 vvcurveto
-        77 -77 58 -216 95 vhcurveto
-        -63 -112 rlineto
-        136 -58 63 -42 -46 vvcurveto
-        hintmask 01000000
-        -62 -123 -35 -83 vvcurveto
-        -39 25 -37 73 -27 vhcurveto
-        hintmask 10010000
-        -100 -26 -38 -53 -46 vvcurveto
-        hintmask 00100000
-        -54 62 -64 -37 vvcurveto
-        -46 -78 -31 -185 -31 vhcurveto
-        endchar
+        688 -107 callsubr
+        return
       
     </CharString>
     
       
     <CharString index="64">
+        
+        895 -58 callsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="65">
+        
+        -66 callgsubr
+        -70 callgsubr
+      
+    </CharString>
+    
+      
+    <CharString index="66">
         
         154 -263 72 101 vvcurveto
         38 33 27 47 51 33 -25 -71 20 vhcurveto
@@ -741,61 +782,33 @@
     </CharString>
     
       
-    <CharString index="65">
-        
-        -181 -129 -169 -192 return
-      
-    </CharString>
-    
-      
-    <CharString index="66">
-        
-        -28 callgsubr
-        -40 callsubr
-        return
-      
-    </CharString>
-    
-      
     <CharString index="67">
         
-        -23 callsubr
-        -35 callgsubr
-        return
+        181 129 170 192 return
       
     </CharString>
     
       
     <CharString index="68">
         
-        hstem
-        68 157 127 49 callsubr
-        return
+        132 111 131 return
       
     </CharString>
     
       
     <CharString index="69">
         
-        -199 229 -107 107 hstemhm
-        319 131 hintmask 01100000
-        125 -150 rmoveto
-        76 -24 rlineto
-        14 callsubr
-        hintmask 10100000
-        14 callgsubr
-        131 3 rlineto
-        hintmask 01100000
-        153 9 -69 73 -84 hhcurveto
-        -73 -57 -57 -123 -51 hvcurveto
-        endchar
+        -17 callgsubr
+        -31 callgsubr
+        return
       
     </CharString>
     
       
     <CharString index="70">
         
-        -75 -61 -158 -84 -18 callgsubr
+        -16 callgsubr
+        -31 callsubr
         return
       
     </CharString>
@@ -803,23 +816,17 @@
       
     <CharString index="71">
         
-        -2 callsubr
-        hintmask 10110000
-        -132 -683 -6 callsubr
-        -159 -16 rmoveto
-        hintmask 01110000
-        8 callgsubr
-        85 438 rlineto
-        98 7 43 -52 -102 vvcurveto
-        endchar
+        hstem
+        40 156 153 147 vstem
+        return
       
     </CharString>
     
       
     <CharString index="72">
         
+        -47 callsubr
         hstem
-        55 167 221 168 vstem
         return
       
     </CharString>
@@ -827,14 +834,40 @@
       
     <CharString index="73">
         
-        hstem
-        54 149 230 146 vstem
-        return
+        -11 callgsubr
+        -17 1 -15 1 -15 return
       
     </CharString>
     
       
     <CharString index="74">
+        
+        167 118 268 135 return
+      
+    </CharString>
+    
+      
+    <CharString index="75">
+        
+        rmoveto
+        140 -222 125 81 -140 214 217 210 -95 96 -216 -224 rlineto
+        249 -149 rmoveto
+        137 -228 125 78 -136 219 217 203 -93 99 -217 -217 rlineto
+        endchar
+      
+    </CharString>
+    
+      
+    <CharString index="76">
+        
+        hstem
+        48 157 217 71 callgsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="77">
         
         rmoveto
         -84 98 rlineto
@@ -848,14 +881,24 @@
     </CharString>
     
       
-    <CharString index="75">
+    <CharString index="78">
+        
+        hlineto
+        269 168 -52 callgsubr
+        -195 194 rlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="79">
         
         113 -52 111 74 110 return
       
     </CharString>
     
       
-    <CharString index="76">
+    <CharString index="80">
         
         rmoveto
         93 -99 217 216 33 155 -137 227 -125 -78 136 -219 rlineto
@@ -866,59 +909,69 @@
     </CharString>
     
       
-    <CharString index="77">
+    <CharString index="81">
         
-        -236 102 hstem
-        121 139 vstem
-        454 1 rmoveto
-        -42 58 rlineto
-        -213 -60 -78 -77 -69 39 callgsubr
-        -8 callgsubr
+        626 119 hstem
+        114 460 vstem
+        574 791 -102 callgsubr
         endchar
       
     </CharString>
     
       
-    <CharString index="78">
+    <CharString index="82">
         
         106 553 rlineto
         182 hlineto
         27 135 rlineto
         -525 hlineto
-        -27 -135 rlineto
-        181 hlineto
+        -27 -135 93 callgsubr
         -106 -553 rlineto
         return
       
     </CharString>
     
       
-    <CharString index="79">
+    <CharString index="83">
         
         -14 132 328 129 return
       
     </CharString>
     
       
-    <CharString index="80">
+    <CharString index="84">
         
-        -50 callsubr
+        -48 callsubr
         hstem
         47 return
       
     </CharString>
     
       
-    <CharString index="81">
+    <CharString index="85">
         
-        -11 137 442 134 hstem
-        115 162 95 168 vstem
+        -189 141 89 135 1 callgsubr
         return
       
     </CharString>
     
       
-    <CharString index="82">
+    <CharString index="86">
+        
+        31 643 vstem
+        323 688 rmoveto
+        -158 hlineto
+        -134 -688 rlineto
+        159 hlineto
+        73 343 rmoveto
+        131 -353 168 20 -134 330 246 348 rlineto
+        -169 hlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="87">
         
         -16 128 321 144 hstem
         429 153 vstem
@@ -930,52 +983,9 @@
     </CharString>
     
       
-    <CharString index="83">
-        
-        -16 147 -39 callgsubr
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="84">
-        
-        454 hlineto
-        26 135 rlineto
-        -292 hlineto
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="85">
-        
-        -16 127 342 126 return
-      
-    </CharString>
-    
-      
-    <CharString index="86">
-        
-        -24 callsubr
-        -80 153 return
-      
-    </CharString>
-    
-      
-    <CharString index="87">
-        
-        623 251 hstem
-        155 363 vstem
-        155 -47 callsubr
-        endchar
-      
-    </CharString>
-    
-      
     <CharString index="88">
         
-        782 -64 callgsubr
+        -16 147 -37 callsubr
         return
       
     </CharString>
@@ -983,31 +993,84 @@
       
     <CharString index="89">
         
-        vvcurveto
-        -91 84 -24 159 99 vhcurveto
-        return
+        -17 callsubr
+        24 130 return
       
     </CharString>
     
       
     <CharString index="90">
         
-        32 callgsubr
-        339 hmoveto
-        -29 callgsubr
-        return
+        -16 127 342 126 return
       
     </CharString>
     
       
     <CharString index="91">
         
-        0 125 438 125 return
+        -14 136 443 137 return
       
     </CharString>
     
       
     <CharString index="92">
+        
+        -20 callsubr
+        -80 153 return
+      
+    </CharString>
+    
+      
+    <CharString index="93">
+        
+        -107 -1322 380 hstem
+        -849 400 vstem
+        -449 -291 -90 callsubr
+      
+    </CharString>
+    
+      
+    <CharString index="94">
+        
+        782 -64 callgsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="95">
+        
+        hstemhm
+        343 162 -101 165 return
+      
+    </CharString>
+    
+      
+    <CharString index="96">
+        
+        -177 -186 -247 -306 return
+      
+    </CharString>
+    
+      
+    <CharString index="97">
+        
+        49 callsubr
+        339 hmoveto
+        -25 callgsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="98">
+        
+        -12 133 314 129 return
+      
+    </CharString>
+    
+      
+    <CharString index="99">
         
         rlineto
         -159 hlineto
@@ -1016,7 +1079,7 @@
     </CharString>
     
       
-    <CharString index="93">
+    <CharString index="100">
         
         rmoveto
         17 -147 rlineto
@@ -1034,40 +1097,48 @@
     </CharString>
     
       
-    <CharString index="94">
+    <CharString index="101">
         
         hstemhm
-        58 -32 callgsubr
+        58 -28 callgsubr
         return
       
     </CharString>
     
       
-    <CharString index="95">
+    <CharString index="102">
         
-        615 243 hstem
-        134 435 vstem
-        311 615 -82 callsubr
+        144 346 vstem
+        459 619 -95 callsubr
         endchar
       
     </CharString>
     
       
-    <CharString index="96">
+    <CharString index="103">
         
         69 rlineto
-        -102 3 callgsubr
+        -102 12 callsubr
         return
       
     </CharString>
     
       
-    <CharString index="97">
+    <CharString index="104">
+        
+        111 435 vstem
+        336 725 -88 callsubr
+        endchar
+      
+    </CharString>
+    
+      
+    <CharString index="105">
         
         rmoveto
         191 977 rlineto
         -362 hlineto
-        -25 -122 65 callsubr
+        -25 -122 93 callsubr
         -141 -733 rlineto
         -207 hlineto
         -24 -122 rlineto
@@ -1076,25 +1147,16 @@
     </CharString>
     
       
-    <CharString index="98">
+    <CharString index="106">
         
-        -13 131 58 callgsubr
-        9 callgsubr
+        -13 131 82 callgsubr
+        19 callsubr
         return
       
     </CharString>
     
       
-    <CharString index="99">
-        
-        -15 -11 callgsubr
-        32 52 40 142 30 vhcurveto
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="100">
+    <CharString index="107">
         
         rlineto
         2 -14 -13 0 -12 hhcurveto
@@ -1104,34 +1166,49 @@
     </CharString>
     
       
-    <CharString index="101">
+    <CharString index="108">
         
         hstem
-        178 66 callgsubr
+        65 155 161 132 vstem
         return
       
     </CharString>
     
       
-    <CharString index="102">
+    <CharString index="109">
         
-        98 180 95 hstem
+        27 132 rlineto
         return
       
     </CharString>
     
       
-    <CharString index="103">
+    <CharString index="110">
         
-        657 128 hstem
-        114 426 vstem
-        515 657 -64 callgsubr
-        endchar
+        rlineto
+        418 -53 149 235 250 vvcurveto
+        return
       
     </CharString>
     
       
-    <CharString index="104">
+    <CharString index="111">
+        
+        146 hlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="112">
+        
+        26 46 callsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="113">
         
         114 134 113 vstem
         return
@@ -1139,16 +1216,16 @@
     </CharString>
     
       
-    <CharString index="105">
+    <CharString index="114">
         
-        -32 callgsubr
-        hintmask 11011000
-        return
+        rmoveto
+        206 -240 111 106 -181 200 278 193 -87 121 -289 -226 rlineto
+        endchar
       
     </CharString>
     
       
-    <CharString index="106">
+    <CharString index="115">
         
         562 134 hstem
         435 160 vstem
@@ -1157,55 +1234,77 @@
     </CharString>
     
       
-    <CharString index="107">
+    <CharString index="116">
         
-        -197 -162 -213 -236 return
+        -14 136 34 callsubr
+        return
       
     </CharString>
     
       
-    <CharString index="108">
+    <CharString index="117">
         
-        156 189 141 return
+        hintmask 1000010001001000111100010001000010101100
+        return
       
     </CharString>
     
       
-    <CharString index="109">
+    <CharString index="118">
         
         hstem
-        21 callsubr
+        35 callsubr
         vstem
         return
       
     </CharString>
     
       
-    <CharString index="110">
+    <CharString index="119">
         
-        -29 -40 15 32 vvcurveto
+        156 189 141 return
+      
+    </CharString>
+    
+      
+    <CharString index="120">
+        
+        rlineto
+        -145 hlineto
         return
       
     </CharString>
     
       
-    <CharString index="111">
+    <CharString index="121">
         
-        -14 24 121 -145 14 38 154 -148 13 -34 -153 -161 15 -25 -122 158 -15 return
+        rmoveto
+        87 -121 289 225 38 154 -206 240 -111 -105 180 -201 rlineto
+        endchar
       
     </CharString>
     
       
-    <CharString index="112">
+    <CharString index="122">
         
-        -7 127 331 118 -117 122 hstemhm
-        16 158 76 144 114 141 hintmask 11011100
+        40 24 53 60 60 vhcurveto
+        16 callgsubr
+        -29 -17 16 38 hvcurveto
         return
       
     </CharString>
     
       
-    <CharString index="113">
+    <CharString index="123">
+        
+        18 -48 24 -51 30 -53 rrcurveto
+        -40 -44 -38 -15 -28 hhcurveto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="124">
         
         55 -62 63 38 vvcurveto
         45 79 31 184 31 vhcurveto
@@ -1216,33 +1315,7 @@
     </CharString>
     
       
-    <CharString index="114">
-        
-        hstem
-        61 161 218 150 vstem
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="115">
-        
-        -155 -77 -142 -149 6 vhcurveto
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="116">
-        
-        hstem
-        59 154 217 140 vstem
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="117">
+    <CharString index="125">
         
         -14 120 hstem
         294 160 vstem
@@ -1251,30 +1324,67 @@
     </CharString>
     
       
-    <CharString index="118">
+    <CharString index="126">
         
-        -4 -2 -3 -8 -9 2 -3 4 4 2 3 9 return
-      
-    </CharString>
-    
-      
-    <CharString index="119">
-        
-        hintmask 1000010001001000111100010011000010101100
+        hstem
+        61 161 218 150 vstem
         return
       
     </CharString>
     
       
-    <CharString index="120">
+    <CharString index="127">
         
-        120 160 45 callgsubr
+        -9 callsubr
+        hstem
+        28 return
+      
+    </CharString>
+    
+      
+    <CharString index="128">
+        
+        hlineto
+        2 callgsubr
         return
       
     </CharString>
     
       
-    <CharString index="121">
+    <CharString index="129">
+        
+        -66 callgsubr
+        -157 return
+      
+    </CharString>
+    
+      
+    <CharString index="130">
+        
+        20 callgsubr
+        583 vstem
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="131">
+        
+        95 86 3 callsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="132">
+        
+        112 134 114 vstem
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="133">
         
         24 11 -32 -90 -4 hvcurveto
         return
@@ -1282,24 +1392,17 @@
     </CharString>
     
       
-    <CharString index="122">
+    <CharString index="134">
         
-        101 241 99 return
-      
-    </CharString>
-    
-      
-    <CharString index="123">
-        
-        rmoveto
-        -63 27 -83 -55 -63 -93 -16 -98 rlinecurve
-        191 2 -6 68 12 83 28 66 rlinecurve
+        31 callsubr
+        57 callsubr
+        hintmask 01111000
         return
       
     </CharString>
     
       
-    <CharString index="124">
+    <CharString index="135">
         
         hhcurveto
         55 1 -64 -75 -42 hvcurveto
@@ -1310,17 +1413,55 @@
     </CharString>
     
       
-    <CharString index="125">
+    <CharString index="136">
         
-        26 134 rlineto
-        -339 hlineto
-        -27 -134 rlineto
+        vstem
+        6 callsubr
+        64 -63 rlineto
         return
       
     </CharString>
     
       
-    <CharString index="126">
+    <CharString index="137">
+        
+        37 94 callgsubr
+        -140 hlineto
+        -36 -187 rlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="138">
+        
+        26 134 rlineto
+        -339 63 callgsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="139">
+        
+        rmoveto
+        84 callgsubr
+        33 168 rlineto
+        -181 hlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="140">
+        
+        -244 39 callsubr
+        72 95 return
+      
+    </CharString>
+    
+      
+    <CharString index="141">
         
         685 7 hstem
         104 582 vstem
@@ -1329,7 +1470,7 @@
     </CharString>
     
       
-    <CharString index="127">
+    <CharString index="142">
         
         100 240 105 hstem
         return
@@ -1337,106 +1478,139 @@
     </CharString>
     
       
-    <CharString index="128">
+    <CharString index="143">
         
         rlineto
-        49 callgsubr
+        70 callsubr
         return
       
     </CharString>
     
       
-    <CharString index="129">
+    <CharString index="144">
         
-        101 244 99 return
+        78 hstem
+        50 87 376 87 vstem
+        50 269 rmoveto
+        -169 92 -92 135 return
       
     </CharString>
     
       
-    <CharString index="130">
+    <CharString index="145">
         
-        -5 callsubr
-        44 194 3 callsubr
+        4 callgsubr
+        44 194 13 callgsubr
         return
       
     </CharString>
     
       
-    <CharString index="131">
+    <CharString index="146">
         
-        -235 15 callgsubr
+        -235 26 callsubr
         return
       
     </CharString>
     
       
-    <CharString index="132">
+    <CharString index="147">
         
-        88 280 95 return
-      
-    </CharString>
-    
-      
-    <CharString index="133">
-        
-        0 129 38 112 13 106 161 129 hstem
-        -39 718 vstem
+        rlineto
+        150 hlineto
         return
       
     </CharString>
     
       
-    <CharString index="134">
+    <CharString index="148">
         
-        66 callsubr
-        523 -25 callsubr
+        94 callsubr
+        523 -19 callsubr
         return
       
     </CharString>
     
       
-    <CharString index="135">
+    <CharString index="149">
+        
+        95 vvcurveto
+        105 -66 51 -178 -25 vhcurveto
+        -134 -689 rlineto
+        111 hlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="150">
+        
+        0 133 297 133 return
+      
+    </CharString>
+    
+      
+    <CharString index="151">
         
         0 139 411 138 return
       
     </CharString>
     
       
-    <CharString index="136">
+    <CharString index="152">
         
-        -10 136 435 142 return
+        132 hstemhm
+        441 159 return
       
     </CharString>
     
       
-    <CharString index="137">
+    <CharString index="153">
         
-        -7 8 -8 133 438 29 callsubr
+        269 134 hstem
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="154">
+        
+        -7 8 -8 133 438 45 callgsubr
         hintmask 01110000
         return
       
     </CharString>
     
       
-    <CharString index="138">
+    <CharString index="155">
         
-        -16 134 453 133 hstem
-        58 165 219 166 vstem
+        -71 68 -56 -39 vvcurveto
+        -26 -31 -18 -119 -5 vhcurveto
+        -24 -108 rlineto
         return
       
     </CharString>
     
       
-    <CharString index="139">
+    <CharString index="156">
         
-        553 135 hstem
-        102 552 vstem
+        -16 124 348 123 hstem
+        48 154 222 155 vstem
         return
       
     </CharString>
     
       
-    <CharString index="140">
+    <CharString index="157">
+        
+        rlineto
+        -180 hlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="158">
         
         rlinecurve
         -191 return
@@ -1444,16 +1618,25 @@
     </CharString>
     
       
-    <CharString index="141">
+    <CharString index="159">
         
-        301 642 rmoveto
-        167 7 47 157 -177 -9 rlineto
-        return
+        164 hstem
+        77 152 145 98 34 83 callgsubr
+        472 return
       
     </CharString>
     
       
-    <CharString index="142">
+    <CharString index="160">
+        
+        -51 -130 -32 -102 vvcurveto
+        -76 77 -58 216 -96 vhcurveto
+        endchar
+      
+    </CharString>
+    
+      
+    <CharString index="161">
         
         4 2 2 4 1 hvcurveto
         5 hlineto
@@ -1463,39 +1646,50 @@
     </CharString>
     
       
-    <CharString index="143">
+    <CharString index="162">
         
-        30 hhcurveto
-        28 24 -26 -62 -101 -62 -132 -66 hvcurveto
+        rmoveto
+        26 132 rlineto
+        -472 hlineto
+        -25 -132 rlineto
         endchar
       
     </CharString>
     
       
-    <CharString index="144">
+    <CharString index="163">
         
-        -190 141 502 124 return
+        hlineto
+        -37 -189 rlineto
+        139 hlineto
+        return
       
     </CharString>
     
       
-    <CharString index="145">
+    <CharString index="164">
+        
+        -9 -7 -7 -9 -9 -7 6 10 return
+      
+    </CharString>
+    
+      
+    <CharString index="165">
         
         -35 -29 29 35 35 29 29 35 return
       
     </CharString>
     
       
-    <CharString index="146">
+    <CharString index="166">
         
-        vvcurveto
-        -81 102 -51 194 91 vhcurveto
-        return
+        39 callgsubr
+        85 95 return
       
     </CharString>
     
       
-    <CharString index="147">
+    <CharString index="167">
         
         hintmask 1100010001001000111100010001010000101100
         return
@@ -1503,23 +1697,15 @@
     </CharString>
     
       
-    <CharString index="148">
+    <CharString index="168">
         
-        hintmask 1000010001001000111100010100000010101100
+        hintmask 1000010001010000111100010000100010101100
         return
       
     </CharString>
     
       
-    <CharString index="149">
-        
-        88 119 73 hstem
-        return
-      
-    </CharString>
-    
-      
-    <CharString index="150">
+    <CharString index="169">
         
         99 263 99 hstem
         return
@@ -1527,16 +1713,45 @@
     </CharString>
     
       
-    <CharString index="151">
+    <CharString index="170">
         
-        152 132 111 131 hstem
-        51 547 vstem
+        hlineto
+        -27 -134 rlineto
         return
       
     </CharString>
     
       
-    <CharString index="152">
+    <CharString index="171">
+        
+        vstem
+        229 346 rmoveto
+        189 hlineto
+        34 94 callgsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="172">
+        
+        rmoveto
+        1723 21 callgsubr
+        -1723 hlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="173">
+        
+        153 hstem
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="174">
         
         118 vstem
         return
@@ -1544,22 +1759,15 @@
     </CharString>
     
       
-    <CharString index="153">
+    <CharString index="175">
         
-        -125 rlineto
+        -344 -215 63 -122 279 180 rlineto
         return
       
     </CharString>
     
       
-    <CharString index="154">
-        
-        141 -101 150 -128 147 -46 157 return
-      
-    </CharString>
-    
-      
-    <CharString index="155">
+    <CharString index="176">
         
         62 123 36 83 vvcurveto
         39 -25 36 -73 27 vhcurveto
@@ -1568,49 +1776,62 @@
     </CharString>
     
       
-    <CharString index="156">
+    <CharString index="177">
         
-        -162 hlineto
+        -243 rmoveto
+        2 callgsubr
         return
       
     </CharString>
     
       
-    <CharString index="157">
+    <CharString index="178">
         
-        15 callgsubr
-        hstem
+        157 vstem
         return
       
     </CharString>
     
       
-    <CharString index="158">
+    <CharString index="179">
         
-        hstem
-        50 597 vstem
-        return
+        92 callgsubr
+        -27 return
       
     </CharString>
     
       
-    <CharString index="159">
+    <CharString index="180">
+        
+        0 135 hstem
+        55 return
+      
+    </CharString>
+    
+      
+    <CharString index="181">
         
         18 130 return
       
     </CharString>
     
       
-    <CharString index="160">
+    <CharString index="182">
         
-        -205 1209 hstem
-        -20 692 vstem
+        -91 50 -61 97 69 73 31 66 76 vhcurveto
         return
       
     </CharString>
     
       
-    <CharString index="161">
+    <CharString index="183">
+        
+        -83 89 -123 -188 -141 -213 return
+      
+    </CharString>
+    
+      
+    <CharString index="184">
         
         hintmask 1000010001001000111010010001000010101100
         return
@@ -1618,23 +1839,23 @@
     </CharString>
     
       
-    <CharString index="162">
+    <CharString index="185">
         
-        hintmask 1000010001010000111100010001000010101100
+        hintmask 1000010001000100111100010011000010101100
         return
       
     </CharString>
     
       
-    <CharString index="163">
+    <CharString index="186">
         
-        hintmask 1100010001001000111100010000100010101100
+        hintmask 1000010100001000111100010001000010101100
         return
       
     </CharString>
     
       
-    <CharString index="164">
+    <CharString index="187">
         
         hhcurveto
         hintmask 10100000
@@ -1643,14 +1864,21 @@
     </CharString>
     
       
-    <CharString index="165">
+    <CharString index="188">
+        
+        -215 1031 return
+      
+    </CharString>
+    
+      
+    <CharString index="189">
         
         329 131 return
       
     </CharString>
     
       
-    <CharString index="166">
+    <CharString index="190">
         
         130 vstem
         return
@@ -1658,23 +1886,31 @@
     </CharString>
     
       
-    <CharString index="167">
+    <CharString index="191">
         
-        6 -1 3 -4 -3 -2 -2 -7 vhcurveto
+        181 hlineto
         return
       
     </CharString>
     
       
-    <CharString index="168">
+    <CharString index="192">
         
-        rlineto
-        -150 return
+        142 rlinecurve
+        -184 -4 3 -121 return
       
     </CharString>
     
       
-    <CharString index="169">
+    <CharString index="193">
+        
+        rmoveto
+        -12 76 return
+      
+    </CharString>
+    
+      
+    <CharString index="194">
         
         vvcurveto
         -81 102 -51 193 91 vhcurveto
@@ -1683,34 +1919,67 @@
     </CharString>
     
       
-    <CharString index="170">
+    <CharString index="195">
         
-        186 rlineto
-        -188 hlineto
-        endchar
+        rmoveto
+        113 hlineto
+        108 285 return
       
     </CharString>
     
       
-    <CharString index="171">
+    <CharString index="196">
+        
+        -174 117 hstem
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="197">
         
         hlineto
-        32 163 rlineto
+        -74 -111 rlineto
         return
       
     </CharString>
     
       
-    <CharString index="172">
+    <CharString index="198">
+        
+        271 131 hstem
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="199">
         
         rlineto
-        -190 hlineto
+        -473 hlineto
         return
       
     </CharString>
     
       
-    <CharString index="173">
+    <CharString index="200">
+        
+        rlineto
+        84 callgsubr
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="201">
+        
+        187 rlineto
+        return
+      
+    </CharString>
+    
+      
+    <CharString index="202">
         
         161 vstem
         return

--- a/ligature/OperatorMonoSSmLig-BoldItalic/subrs.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/subrs.xml
@@ -42,7 +42,7 @@
         
             rmoveto
             188 -97 76 -127 -196 -136 -212 -241 -188 96 -75 128 195 137 212 240 vhcurveto
-            -389 59 callsubr
+            -389 83 callsubr
             150 58 161 90 44 29 -38 -94 -150 -57 -161 -90 -45 -29 38 94 vhcurveto
             endchar
           
@@ -193,8 +193,8 @@
     <CharString index="16">
         
             rmoveto
-            -89 callsubr
-            451 hlineto
+            -81 callgsubr
+            -51 -185 97 -73 317 139 rlinecurve
             endchar
           
     </CharString>
@@ -203,7 +203,7 @@
     <CharString index="17">
         
             rmoveto
-            63 -26 83 54 62 93 17 98 33 callgsubr
+            63 -26 83 54 62 93 17 98 51 callgsubr
             -2 6 -68 -13 -83 -27 -66 rlinecurve
             endchar
           
@@ -214,13 +214,13 @@
         
             -152 hlineto
             84 438 rlineto
-            -5 callsubr
+            4 callgsubr
             23 125 rlineto
             -451 hlineto
-            -24 46 callgsubr
-            -5 callsubr
-            -84 -438 3 callsubr
-            -25 46 callgsubr
+            -24 66 callsubr
+            4 callgsubr
+            -84 -438 13 callgsubr
+            -25 66 callsubr
             return
           
     </CharString>
@@ -229,7 +229,7 @@
     <CharString index="19">
         
             rmoveto
-            106 -107 104 79 -177 25 callsubr
+            106 -107 104 79 -177 40 callsubr
             -10 hlineto
             -248 -162 68 -76 rlineto
             return
@@ -270,9 +270,9 @@
             -86 hlineto
             -109 -260 rlineto
             -5 hlineto
-            77 468 -15 callgsubr
+            77 468 -8 callgsubr
             -44 -293 -25 -263 -3 -132 rrcurveto
-            -5 callsubr
+            4 callgsubr
             endchar
           
     </CharString>
@@ -309,7 +309,7 @@
     <CharString index="25">
         
             -62 callgsubr
-            -55 callgsubr
+            -55 callsubr
             return
           
     </CharString>
@@ -317,12 +317,10 @@
           
     <CharString index="26">
         
-            rmoveto
-            67 -51 74 53 91 86 53 60 rlinecurve
-            -140 74 -34 -64 -63 -96 -48 -62 rlinecurve
-            240 -1 rmoveto
-            68 -51 74 53 88 84 52 61 rlinecurve
-            -144 65 -33 -64 -57 -87 -48 -61 rlinecurve
+            -76 -48 36 -60 55 32 49 -144 146 -18 213 121 rlinecurve
+            -119 566 rmoveto
+            21 18 -15 -36 -70 -61 -109 -128 -119 hvcurveto
+            213 6 79 136 65 hhcurveto
             return
           
     </CharString>
@@ -365,7 +363,7 @@
             rmoveto
             144 2 95 396 -150 -5 -31 -138 rlineto
             -115 -30 -51 46 113 vvcurveto
-            138 66 159 95 47 12 -42 -97 -32 callsubr
+            138 66 159 95 47 12 -42 -97 -28 callsubr
             11 -51 90 -135 hhcurveto
             -196 -158 -218 -242 -185 104 -97 191 36 hvcurveto
             return
@@ -401,10 +399,10 @@
     <CharString index="33">
         
             rmoveto
-            0 callgsubr
-            -232 158 -97 299 98 hvcurveto
-            16 140 rlineto
-            -68 callsubr
+            -48 callgsubr
+            -175 139 -121 331 147 hvcurveto
+            -11 80 rlineto
+            -45 callsubr
             endchar
           
     </CharString>
@@ -413,7 +411,7 @@
     <CharString index="34">
         
             91 -92 78 -48 66 vhcurveto
-            111 111 -40 74 -96 57 callgsubr
+            111 111 -40 74 -96 80 callgsubr
             -82 -87 -50 -86 -24 7 -24 12 -22 hvcurveto
             -36 -29 -51 -33 -68 -42 32 -68 rcurveline
             70 34 59 33 48 31 rrcurveto
@@ -473,7 +471,7 @@
     <CharString index="39">
         
             -225 -71 -89 41 145 vvcurveto
-            126 67 158 100 51 11 -37 -103 -32 callsubr
+            126 67 158 100 51 11 -37 -103 -28 callsubr
             9 -49 90 -137 hhcurveto
             return
           
@@ -493,7 +491,7 @@
     <CharString index="41">
         
             161 hlineto
-            43 221 300 467 32 callsubr
+            43 221 300 467 50 callsubr
             -177 -309 -69 313 -165 -7 123 -454 rlineto
             endchar
           
@@ -506,7 +504,8 @@
             -7 75 -206 -39 -30 23 22 88 rlinecurve
             51 234 rlineto
             193 hlineto
-            22 118 65 callgsubr
+            22 118 rlineto
+            -190 hlineto
             36 165 -116 -9 -105 -156 rlineto
             -64 hlineto
             -29 -118 rlineto
@@ -528,11 +527,11 @@
     <CharString index="44">
         
             rmoveto
-            -43 callsubr
+            -40 callgsubr
             47 -9 40 -16 34 hvcurveto
             76 85 -81 60 -62 -69 rlineto
             24 -35 -43 12 -51 hhcurveto
-            -42 callgsubr
+            -40 callsubr
             -48 9 -42 18 -34 hvcurveto
             -75 -83 80 -60 62 68 rlineto
             -23 34 43 -12 50 hhcurveto
@@ -560,45 +559,24 @@
           
     <CharString index="46">
         
-            rmoveto
-            189 136 201 243 69 -12 55 -22 43 hvcurveto
-            67 93 -90 57 -49 -71 rlineto
-            20 -34 -41 10 -45 hhcurveto
-            -189 -135 -201 -243 -68 11 -54 21 -42 hvcurveto
-            -69 -96 89 -57 52 72 rlineto
-            -21 34 41 -10 46 hhcurveto
-            81 587 rmoveto
-            24 19 -11 -21 13 hvcurveto
-            -197 -280 rlineto
-            157 54 155 87 vhcurveto
-            -63 -453 rmoveto
-            -25 -20 11 24 -13 hvcurveto
-            199 281 rlineto
-            -1 vlineto
-            -161 -53 -154 -88 vhcurveto
-            endchar
+            42 52 43 62 44 73 -123 44 rcurveline
+            -24 -48 -24 -41 -22 -35 -23 45 -18 42 -11 40 rrcurveto
+            72 67 40 69 51 vvcurveto
+            52 -44 33 -62 -82 -86 -62 -134 -17 1 -18 3 -19 vhcurveto
+            -152 -118 -48 -108 -92 vvcurveto
+            return
           
     </CharString>
     
           
     <CharString index="47">
         
-            -7 8 -8 133 166 109 163 29 callsubr
-            hintmask 01111000
-            35 callsubr
-            -55 -283 rlineto
-            -61 hlineto
-            -21 -109 rlineto
-            61 hlineto
-            hintmask 10111000
-            -56 -291 -6 callsubr
-            -353 -141 rmoveto
-            93 hlineto
-            28 109 rlineto
-            -100 64 callgsubr
-            98 7 43 -52 -102 vvcurveto
-            hintmask 01111000
-            8 callgsubr
+            -125 55 -61 66 58 69 47 59 60 vhcurveto
+            -5 -112 55 -35 192 108 rrcurveto
+            -344 77 rmoveto
+            -29 -23 25 63 101 62 132 65 18 31 -5 -11 34 hvcurveto
+            -47 -244 rlineto
+            -35 -39 -43 -26 -29 hhcurveto
             endchar
           
     </CharString>
@@ -606,7 +584,8 @@
           
     <CharString index="48">
         
-            916 -102 callgsubr
+            -19 callsubr
+            549 69 -98 callgsubr
             return
           
     </CharString>
@@ -614,10 +593,9 @@
           
     <CharString index="49">
         
-            -28 callsubr
-            586 51 rmoveto
-            -12 76 rlineto
-            -82 callgsubr
+            rmoveto
+            -164 -6 -2 -90 -11 -83 -27 -89 rlinecurve
+            64 -23 72 86 49 87 19 118 rlinecurve
             return
           
     </CharString>
@@ -625,41 +603,33 @@
           
     <CharString index="50">
         
-            484 hlineto
-            27 140 -301 -3 376 417 22 134 rlineto
-            -473 hlineto
-            -27 -140 298 4 -381 -418 rlineto
-            endchar
+            -65 callgsubr
+            -57 -990 -106 callgsubr
           
     </CharString>
     
           
     <CharString index="51">
         
-            rmoveto
-            169 1 50 153 -182 -1 rlineto
-            return
+            484 hlineto
+            27 140 -301 -3 376 417 22 134 72 callgsubr
+            -140 298 4 -381 -418 rlineto
+            endchar
           
     </CharString>
     
           
     <CharString index="52">
         
-            23 callsubr
-            122 631 -152 -11 -38 -197 -7 callgsubr
-            hintmask 10111000
-            -60 callgsubr
+            -157 -102 -106 106 -104 -79 rlineto
+            return
           
     </CharString>
     
           
     <CharString index="53">
         
-            rmoveto
-            hintmask 01100000
-            -63 callgsubr
-            hintmask 10100000
-            -69 callsubr
+            744 -95 callsubr
             return
           
     </CharString>
@@ -667,9 +637,11 @@
           
     <CharString index="54">
         
-            -33 -48 90 -72 hhcurveto
-            -62 -69 -67 -87 -53 hvcurveto
-            74 -43 rlineto
+            rmoveto
+            hintmask 11011100
+            -63 callgsubr
+            hintmask 11101100
+            -69 callsubr
             return
           
     </CharString>
@@ -677,43 +649,32 @@
           
     <CharString index="55">
         
-            rmoveto
-            -32 -167 rlineto
-            288 hlineto
-            32 129 rlineto
-            -165 64 callgsubr
-            124 hlineto
-            22 106 rlineto
-            -125 hlineto
-            31 161 rlineto
-            159 hlineto
-            26 129 rlineto
-            -392 hlineto
-            -109 -228 -111 -231 -106 -229 rrcurveto
-            154 hlineto
-            72 167 rlineto
-            164 392 rmoveto
-            12 hlineto
-            -54 -280 rlineto
-            -75 hlineto
-            40 94 39 94 38 92 rrcurveto
-            endchar
+            -63 122 -410 -265 -23 -129 313 -327 return
           
     </CharString>
     
           
     <CharString index="56">
         
-            -84 callsubr
-            hintmask 1111110110000000
-            -98 callsubr
+            438 140 hstemhm
+            37 567 -167 167 hintmask 11000000
+            257 215 rmoveto
+            146 -225 172 20 -150 215 rlineto
+            128 96 51 84 69 vvcurveto
+            63 -41 41 -71 -68 -72 -37 -73 -73 vhcurveto
+            61 316 -153 -11 -150 -773 rlineto
+            151 hlineto
+            67 347 rlineto
+            55 52 48 36 43 80 callgsubr
+            25 14 -12 -22 -38 -40 -60 -140 -91 hvcurveto
+            return
           
     </CharString>
     
           
     <CharString index="57">
         
-            0 -49 callgsubr
+            850 -88 callsubr
             return
           
     </CharString>
@@ -721,8 +682,12 @@
           
     <CharString index="58">
         
-            5 callsubr
-            529 59 -65 callsubr
+            -36 -156 rlineto
+            172 -18 86 -23 -61 vvcurveto
+            -50 -56 -39 -148 -77 vhcurveto
+            48 -81 rlineto
+            239 116 94 94 94 vvcurveto
+            109 -126 65 -273 27 vhcurveto
             return
           
     </CharString>
@@ -730,14 +695,15 @@
           
     <CharString index="59">
         
-            -12 230 -14 227 -15 225 return
+            0 -47 callgsubr
+            return
           
     </CharString>
     
           
     <CharString index="60">
         
-            688 -107 callsubr
+            152 -39 callgsubr
             return
           
     </CharString>
@@ -745,7 +711,8 @@
           
     <CharString index="61">
         
-            895 -58 callgsubr
+            22 callgsubr
+            -501 -74 callgsubr
             return
           
     </CharString>
@@ -753,16 +720,17 @@
           
     <CharString index="62">
         
-            -66 callgsubr
-            -70 callgsubr
+            -253 -36 -52 26 111 vvcurveto
+            112 67 101 87 47 17 -27 -66 -1 vhcurveto
+            return
           
     </CharString>
     
           
     <CharString index="63">
         
-            -23 callgsubr
-            107 553 21 callgsubr
+            -36 callsubr
+            -32 callsubr
             return
           
     </CharString>
@@ -770,16 +738,28 @@
           
     <CharString index="64">
         
-            181 129 170 192 return
+            632 11 callsubr
+            84 491 hintmask 10100000
+            421 747 -53 callgsubr
+            endchar
           
     </CharString>
     
           
     <CharString index="65">
         
-            626 274 hstem
-            152 522 vstem
-            152 678 -81 callsubr
+            51 130 32 102 vvcurveto
+            77 -77 58 -216 95 vhcurveto
+            -63 -112 rlineto
+            136 -58 63 -42 -46 vvcurveto
+            hintmask 01000000
+            -62 -123 -35 -83 vvcurveto
+            -39 25 -37 73 -27 vhcurveto
+            hintmask 10010000
+            -100 -26 -38 -53 -46 vvcurveto
+            hintmask 00100000
+            -54 62 -64 -37 vvcurveto
+            -46 -78 -31 -185 -31 vhcurveto
             endchar
           
     </CharString>
@@ -787,8 +767,8 @@
           
     <CharString index="66">
         
-            -22 callgsubr
-            -35 callsubr
+            -18 callsubr
+            107 553 36 callgsubr
             return
           
     </CharString>
@@ -796,56 +776,106 @@
           
     <CharString index="67">
         
-            hstem
-            40 156 153 147 vstem
-            return
+            -181 -129 -169 -192 return
           
     </CharString>
     
           
     <CharString index="68">
         
-            -13 131 87 82 168 124 return
+            626 274 hstem
+            152 522 vstem
+            152 678 -80 callgsubr
+            endchar
           
     </CharString>
     
           
     <CharString index="69">
         
-            -19 callsubr
-            -17 1 -15 1 -15 return
+            -24 callgsubr
+            -36 callgsubr
+            return
           
     </CharString>
     
           
     <CharString index="70">
         
-            167 118 268 135 return
+            hstem
+            68 157 127 71 callgsubr
+            return
           
     </CharString>
     
           
     <CharString index="71">
         
-            rmoveto
-            140 -222 125 81 -140 214 217 210 -95 96 -216 -224 rlineto
-            249 -149 rmoveto
-            137 -228 125 78 -136 219 217 203 -93 99 -217 -217 rlineto
-            endchar
+            -13 131 87 82 168 124 return
           
     </CharString>
     
           
     <CharString index="72">
         
-            hstem
-            48 157 217 49 callsubr
-            return
+            -199 229 -107 107 hstemhm
+            319 131 hintmask 01100000
+            125 -150 rmoveto
+            76 -24 rlineto
+            25 callsubr
+            hintmask 10100000
+            26 callgsubr
+            131 3 rlineto
+            hintmask 01100000
+            153 9 -69 73 -84 hhcurveto
+            -73 -57 -57 -123 -51 hvcurveto
+            endchar
           
     </CharString>
     
           
     <CharString index="73">
+        
+            -75 -61 -158 -84 -12 callsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="74">
+        
+            8 callsubr
+            hintmask 10110000
+            -132 -683 3 callgsubr
+            -159 -16 rmoveto
+            hintmask 01110000
+            20 callsubr
+            85 438 rlineto
+            98 7 43 -52 -102 vvcurveto
+            endchar
+          
+    </CharString>
+    
+          
+    <CharString index="75">
+        
+            hstem
+            54 149 230 146 vstem
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="76">
+        
+            hstem
+            55 167 221 168 vstem
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="77">
         
             rmoveto
             84 -99 rlineto
@@ -859,16 +889,16 @@
     </CharString>
     
           
-    <CharString index="74">
+    <CharString index="78">
         
-            -37 callsubr
-            2 callgsubr
+            -33 callgsubr
+            11 callgsubr
             return
           
     </CharString>
     
           
-    <CharString index="75">
+    <CharString index="79">
         
             -2 vhcurveto
             150 2 rlineto
@@ -877,45 +907,10 @@
     </CharString>
     
           
-    <CharString index="76">
-        
-            59 callgsubr
-            176 472 -84 callgsubr
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="77">
-        
-            626 119 hstem
-            114 460 vstem
-            574 791 -102 callgsubr
-            endchar
-          
-    </CharString>
-    
-          
-    <CharString index="78">
-        
-            51 64 169 110 vvcurveto
-            61 -24 53 -78 return
-          
-    </CharString>
-    
-          
-    <CharString index="79">
-        
-            -13 130 -18 callsubr
-            hintmask 11000000
-            return
-          
-    </CharString>
-    
-          
     <CharString index="80">
         
-            -189 141 89 135 -7 callsubr
+            83 callgsubr
+            176 472 -84 callgsubr
             return
           
     </CharString>
@@ -923,30 +918,61 @@
           
     <CharString index="81">
         
-            31 643 vstem
-            323 688 rmoveto
-            -158 hlineto
-            -134 -688 rlineto
-            159 hlineto
-            73 343 rmoveto
-            131 -353 168 20 -134 330 246 348 rlineto
-            -169 hlineto
-            return
+            -236 102 hstem
+            121 139 vstem
+            454 1 rmoveto
+            -42 58 rlineto
+            -213 -60 -78 -77 -69 58 callsubr
+            0 callsubr
+            endchar
           
     </CharString>
     
           
     <CharString index="82">
         
-            151 hstem
-            124 1 callgsubr
-            vstem
-            return
+            51 64 169 110 vvcurveto
+            61 -24 53 -78 return
           
     </CharString>
     
           
     <CharString index="83">
+        
+            -13 130 -12 callgsubr
+            hintmask 11000000
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="84">
+        
+            -11 137 442 134 hstem
+            115 162 95 168 vstem
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="85">
+        
+            hlineto
+            -27 -131 rlineto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="86">
+        
+            -13 callsubr
+            endchar
+          
+    </CharString>
+    
+          
+    <CharString index="87">
         
             -11 136 -136 139 hstemhm
             211 261 return
@@ -954,16 +980,36 @@
     </CharString>
     
           
-    <CharString index="84">
+    <CharString index="88">
         
-            -14 136 443 137 return
+            151 hstem
+            124 12 callgsubr
+            vstem
+            return
           
     </CharString>
     
           
-    <CharString index="85">
+    <CharString index="89">
         
-            643 45 callsubr
+            454 hlineto
+            26 135 rlineto
+            -292 hlineto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="90">
+        
+            63 -122 409 264 return
+          
+    </CharString>
+    
+          
+    <CharString index="91">
+        
+            643 66 callgsubr
             105 466 vstem
             356 644 -100 callgsubr
             endchar
@@ -971,7 +1017,7 @@
     </CharString>
     
           
-    <CharString index="86">
+    <CharString index="92">
         
             28 -127 rlineto
             hintmask 00100000
@@ -987,57 +1033,70 @@
     </CharString>
     
           
-    <CharString index="87">
+    <CharString index="93">
         
-            -107 -1322 380 hstem
-            -849 400 vstem
-            -449 -291 -90 callsubr
-          
-    </CharString>
-    
-          
-    <CharString index="88">
-        
-            -177 -186 -247 -306 return
-          
-    </CharString>
-    
-          
-    <CharString index="89">
-        
-            hstemhm
-            343 162 -101 165 return
-          
-    </CharString>
-    
-          
-    <CharString index="90">
-        
-            604 291 hstem
-            279 204 vstem
-            483 -46 callsubr
+            623 251 hstem
+            155 363 vstem
+            155 -44 callgsubr
             endchar
           
     </CharString>
     
           
-    <CharString index="91">
+    <CharString index="94">
         
-            -12 133 314 129 return
-          
-    </CharString>
-    
-          
-    <CharString index="92">
-        
-            -16 callsubr
-            -6 callgsubr
+            -18 callgsubr
+            rlineto
             return
           
     </CharString>
     
           
-    <CharString index="93">
+    <CharString index="95">
+        
+            vvcurveto
+            -91 84 -24 159 99 vhcurveto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="96">
+        
+            hlineto
+            -27 -132 rlineto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="97">
+        
+            604 291 hstem
+            279 204 vstem
+            483 -43 callgsubr
+            endchar
+          
+    </CharString>
+    
+          
+    <CharString index="98">
+        
+            0 125 438 125 return
+          
+    </CharString>
+    
+          
+    <CharString index="99">
+        
+            -9 callgsubr
+            1 callsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="100">
         
             616 243 hstem
             186 302 vstem
@@ -1047,16 +1106,27 @@
     </CharString>
     
           
-    <CharString index="94">
+    <CharString index="101">
         
-            144 346 vstem
-            459 619 -95 callsubr
+            615 243 hstem
+            134 435 vstem
+            311 615 -82 callsubr
             endchar
           
     </CharString>
     
           
-    <CharString index="95">
+    <CharString index="102">
+        
+            rmoveto
+            -148 -3 -194 -998 rlineto
+            147 hlineto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="103">
         
             23 29 hhcurveto
             27 11 -19 -29 hvcurveto
@@ -1065,92 +1135,112 @@
     </CharString>
     
           
-    <CharString index="96">
+    <CharString index="104">
         
             rmoveto
             -191 -977 rlineto
             362 hlineto
             25 122 rlineto
             -207 hlineto
-            141 733 65 callsubr
+            141 733 93 callsubr
             24 122 rlineto
             endchar
           
     </CharString>
     
           
-    <CharString index="97">
+    <CharString index="105">
         
-            111 435 vstem
-            336 725 -88 callsubr
-            endchar
-          
-    </CharString>
-    
-          
-    <CharString index="98">
-        
-            -15 144 433 141 8 callsubr
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="99">
-        
-            -27 callgsubr
+            -23 callgsubr
             569 vstem
             return
           
     </CharString>
     
           
-    <CharString index="100">
+    <CharString index="106">
+        
+            -15 144 433 141 18 callsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="107">
+        
+            -15 -4 callgsubr
+            32 52 40 142 30 vhcurveto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="108">
         
             hstem
-            65 155 161 132 vstem
+            178 95 callgsubr
             return
           
     </CharString>
     
           
-    <CharString index="101">
+    <CharString index="109">
         
-            rlineto
-            418 -53 149 235 250 vvcurveto
+            hlineto
+            30 callgsubr
+            -179 -22 callsubr
+            181 56 callgsubr
             return
           
     </CharString>
     
           
-    <CharString index="102">
+    <CharString index="110">
         
-            146 hlineto
+            98 180 95 hstem
             return
           
     </CharString>
     
           
-    <CharString index="103">
+    <CharString index="111">
         
-            644 45 callsubr
+            657 128 hstem
+            114 426 vstem
+            515 657 -64 callgsubr
+            endchar
+          
+    </CharString>
+    
+          
+    <CharString index="112">
+        
+            644 66 callgsubr
             215 219 vstem
-            215 643 -56 callsubr
+            215 643 -55 callgsubr
             endchar
           
     </CharString>
     
           
-    <CharString index="104">
+    <CharString index="113">
         
-            rmoveto
-            206 -240 111 106 -181 200 278 193 -87 121 -289 -226 rlineto
-            endchar
+            246 693 rmoveto
+            -107 -104 return
           
     </CharString>
     
           
-    <CharString index="105">
+    <CharString index="114">
+        
+            -28 callgsubr
+            hintmask 11011000
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="115">
         
             rmoveto
             210 -136 88 -299 -47 vhcurveto
@@ -1159,31 +1249,14 @@
     </CharString>
     
           
-    <CharString index="106">
+    <CharString index="116">
         
-            -14 136 20 callsubr
-            return
+            -197 -162 -213 -236 return
           
     </CharString>
     
           
-    <CharString index="107">
-        
-            hintmask 1000010001001000111100010001000010101100
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="108">
-        
-            115 -25 115 hstemhm
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="109">
+    <CharString index="117">
         
             -62 -16 -7 3 20 vvcurveto
             return
@@ -1191,25 +1264,39 @@
     </CharString>
     
           
-    <CharString index="110">
+    <CharString index="118">
         
-            rlineto
-            -145 hlineto
+            115 -25 115 hstemhm
             return
           
     </CharString>
     
           
-    <CharString index="111">
+    <CharString index="119">
         
-            rmoveto
-            87 -121 289 225 38 154 -206 240 -111 -105 180 -201 rlineto
-            endchar
+            -29 -40 15 32 vvcurveto
+            return
           
     </CharString>
     
           
-    <CharString index="112">
+    <CharString index="120">
+        
+            -14 24 121 -145 14 38 154 -148 13 -34 -153 -161 15 -25 -122 158 -15 return
+          
+    </CharString>
+    
+          
+    <CharString index="121">
+        
+            -7 127 331 118 -117 122 hstemhm
+            16 158 76 144 114 141 hintmask 11011100
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="122">
         
             -16 132 324 118 hstem
             146 156 vstem
@@ -1218,7 +1305,7 @@
     </CharString>
     
           
-    <CharString index="113">
+    <CharString index="123">
         
             -140 -179 -135 -175 -236 vhcurveto
             87 14 rmoveto
@@ -1227,25 +1314,7 @@
     </CharString>
     
           
-    <CharString index="114">
-        
-            -16 callgsubr
-            hstem
-            28 return
-          
-    </CharString>
-    
-          
-    <CharString index="115">
-        
-            hstem
-            63 159 227 150 vstem
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="116">
+    <CharString index="124">
         
             hstem
             50 153 165 122 vstem
@@ -1254,77 +1323,10 @@
     </CharString>
     
           
-    <CharString index="117">
-        
-            -66 callgsubr
-            -157 return
-          
-    </CharString>
-    
-          
-    <CharString index="118">
-        
-            7 callsubr
-            583 vstem
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="119">
-        
-            95 86 -5 callgsubr
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="120">
-        
-            112 134 114 vstem
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="121">
-        
-            61 31 29 36 27 hhcurveto
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="122">
-        
-            17 callsubr
-            38 callsubr
-            hintmask 01111000
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="123">
-        
-            vstem
-            55 hmoveto
-            -44 callsubr
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="124">
-        
-            -14 144 -142 128 335 127 return
-          
-    </CharString>
-    
-          
     <CharString index="125">
         
-            0 174 51 callgsubr
+            hstem
+            63 159 227 150 vstem
             return
           
     </CharString>
@@ -1332,16 +1334,16 @@
           
     <CharString index="126">
         
-            -244 25 callgsubr
-            72 95 return
+            hstem
+            59 154 217 140 vstem
+            return
           
     </CharString>
     
           
     <CharString index="127">
         
-            hstem
-            68 66 callgsubr
+            -155 -77 -142 -149 6 vhcurveto
             return
           
     </CharString>
@@ -1349,22 +1351,144 @@
           
     <CharString index="128">
         
-            385 163 return
+            hlineto
+            72 45 -52 callgsubr
+            -78 77 rlineto
+            return
           
     </CharString>
     
           
     <CharString index="129">
         
-            78 hstem
-            50 87 376 87 vstem
-            50 269 rmoveto
-            -169 92 -92 135 return
+            -4 -2 -3 -8 -9 2 -3 4 4 2 3 9 return
           
     </CharString>
     
           
     <CharString index="130">
+        
+            hintmask 1000010001001000111100010011000010101100
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="131">
+        
+            120 160 67 callgsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="132">
+        
+            61 31 29 36 27 hhcurveto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="133">
+        
+            101 241 99 return
+          
+    </CharString>
+    
+          
+    <CharString index="134">
+        
+            rmoveto
+            -63 27 -83 -55 -63 -93 -16 -98 rlinecurve
+            191 2 -6 68 12 83 28 66 rlinecurve
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="135">
+        
+            vstem
+            55 hmoveto
+            -41 callsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="136">
+        
+            5 callgsubr
+            -518 -22 callsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="137">
+        
+            2 callgsubr
+            -519 -11 callsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="138">
+        
+            -14 144 -142 128 335 127 return
+          
+    </CharString>
+    
+          
+    <CharString index="139">
+        
+            -107 -104 270 -267 -2 -13 return
+          
+    </CharString>
+    
+          
+    <CharString index="140">
+        
+            0 174 71 callsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="141">
+        
+            hstem
+            68 95 callgsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="142">
+        
+            385 163 return
+          
+    </CharString>
+    
+          
+    <CharString index="143">
+        
+            101 244 99 return
+          
+    </CharString>
+    
+          
+    <CharString index="144">
+        
+            hlineto
+            -280 -175 -21 callsubr
+          
+    </CharString>
+    
+          
+    <CharString index="145">
         
             rmoveto
             -11 74 -83 -18 -4 1 8 43 rlinecurve
@@ -1373,16 +1497,14 @@
     </CharString>
     
           
-    <CharString index="131">
+    <CharString index="146">
         
-            rlineto
-            150 hlineto
-            return
+            88 280 95 return
           
     </CharString>
     
           
-    <CharString index="132">
+    <CharString index="147">
         
             164 rlineto
             return
@@ -1390,18 +1512,24 @@
     </CharString>
     
           
-    <CharString index="133">
+    <CharString index="148">
         
-            95 vvcurveto
-            105 -66 51 -178 -25 vhcurveto
-            -134 -689 rlineto
-            111 hlineto
+            0 129 38 112 13 106 161 129 hstem
+            -39 718 vstem
             return
           
     </CharString>
     
           
-    <CharString index="134">
+    <CharString index="149">
+        
+            395 45 callsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="150">
         
             122 733 122 hstem
             return
@@ -1409,41 +1537,58 @@
     </CharString>
     
           
-    <CharString index="135">
+    <CharString index="151">
         
-            0 133 297 133 return
+            -10 136 435 142 return
           
     </CharString>
     
           
-    <CharString index="136">
+    <CharString index="152">
         
-            132 hstemhm
-            441 159 return
-          
-    </CharString>
-    
-          
-    <CharString index="137">
-        
-            -16 124 348 123 hstem
-            48 154 222 155 vstem
+            rmoveto
+            5 callgsubr
             return
           
     </CharString>
     
           
-    <CharString index="138">
+    <CharString index="153">
         
-            -71 68 -56 -39 vvcurveto
-            -26 -31 -18 -119 -5 vhcurveto
-            -24 -108 rlineto
+            131 rlineto
             return
           
     </CharString>
     
           
-    <CharString index="139">
+    <CharString index="154">
+        
+            -47 callsubr
+            hstemhm
+            -1187 496 -496 return
+          
+    </CharString>
+    
+          
+    <CharString index="155">
+        
+            -16 134 453 133 hstem
+            58 165 219 166 vstem
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="156">
+        
+            553 135 hstem
+            102 552 vstem
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="157">
         
             rlineto
             -171 hlineto
@@ -1452,51 +1597,58 @@
     </CharString>
     
           
-    <CharString index="140">
+    <CharString index="158">
         
-            164 hstem
-            77 152 145 98 34 59 callgsubr
-            472 return
-          
-    </CharString>
-    
-          
-    <CharString index="141">
-        
-            -51 -130 -32 -102 vvcurveto
-            -76 77 -58 216 -96 vhcurveto
-            endchar
-          
-    </CharString>
-    
-          
-    <CharString index="142">
-        
-            600 433 -2 callsubr
+            301 642 rmoveto
+            167 7 47 157 -177 -9 rlineto
             return
           
     </CharString>
     
           
-    <CharString index="143">
+    <CharString index="159">
         
-            rmoveto
-            26 132 rlineto
-            -472 hlineto
-            -25 -132 rlineto
+            356 87 callsubr
+            -258 -167 rlineto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="160">
+        
+            600 433 8 callsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="161">
+        
+            30 hhcurveto
+            28 24 -26 -62 -101 -62 -132 -66 hvcurveto
             endchar
           
     </CharString>
     
           
-    <CharString index="144">
+    <CharString index="162">
         
-            -9 -7 -7 -9 -9 -7 6 10 return
+            24 130 rlineto
+            -152 -57 rmoveto
+            return
           
     </CharString>
     
           
-    <CharString index="145">
+    <CharString index="163">
+        
+            -190 141 502 124 return
+          
+    </CharString>
+    
+          
+    <CharString index="164">
         
             hstemhm
             41 154 154 149 return
@@ -1504,15 +1656,24 @@
     </CharString>
     
           
-    <CharString index="146">
+    <CharString index="165">
         
-            24 callgsubr
-            85 95 return
+            vvcurveto
+            -81 102 -51 194 91 vhcurveto
+            return
           
     </CharString>
     
           
-    <CharString index="147">
+    <CharString index="166">
+        
+            hintmask 1000010001001000111100010100000010101100
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="167">
         
             hintmask 1000010001001000111100010001000010011100
             return
@@ -1520,15 +1681,7 @@
     </CharString>
     
           
-    <CharString index="148">
-        
-            hintmask 1000010001010000111100010000100010101100
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="149">
+    <CharString index="168">
         
             73 119 87 hstem
             return
@@ -1536,42 +1689,60 @@
     </CharString>
     
           
-    <CharString index="150">
+    <CharString index="169">
+        
+            88 119 73 hstem
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="170">
         
             vstem
-            229 346 rmoveto
-            189 hlineto
-            34 187 rlineto
+            6 callsubr
+            188 -186 rlineto
             return
           
     </CharString>
     
           
-    <CharString index="151">
+    <CharString index="171">
         
-            586 51 58 callsubr
-            2 callsubr
+            586 51 82 callsubr
+            10 callsubr
             return
           
     </CharString>
     
           
-    <CharString index="152">
+    <CharString index="172">
         
-            153 hstem
+            rmoveto
+            183 hlineto
+            34 171 rlineto
+            -184 hlineto
+            endchar
+          
+    </CharString>
+    
+          
+    <CharString index="173">
+        
+            -125 rlineto
             return
           
     </CharString>
     
           
-    <CharString index="153">
+    <CharString index="174">
         
             157 -46 147 -128 150 -101 141 return
           
     </CharString>
     
           
-    <CharString index="154">
+    <CharString index="175">
         
             -88 -2 -73 -375 rlineto
             86 hlineto
@@ -1581,55 +1752,72 @@
     </CharString>
     
           
-    <CharString index="155">
+    <CharString index="176">
         
-            61 callgsubr
-            hlineto
+            141 -101 150 -128 147 -46 157 return
+          
+    </CharString>
+    
+          
+    <CharString index="177">
+        
+            -162 hlineto
             return
           
     </CharString>
     
           
-    <CharString index="156">
+    <CharString index="178">
         
-            157 vstem
+            hstem
+            50 597 vstem
             return
           
     </CharString>
     
           
-    <CharString index="157">
+    <CharString index="179">
         
-            25 callgsubr
+            39 callsubr
             hstemhm
             return
           
     </CharString>
     
           
-    <CharString index="158">
+    <CharString index="180">
         
-            0 135 hstem
-            55 return
+            26 callsubr
+            hstem
+            return
           
     </CharString>
     
           
-    <CharString index="159">
+    <CharString index="181">
         
             82 -87 123 187 143 214 return
           
     </CharString>
     
           
-    <CharString index="160">
+    <CharString index="182">
         
-            -83 89 -123 -188 -141 -213 return
+            -205 1209 hstem
+            -20 692 vstem
+            return
           
     </CharString>
     
           
-    <CharString index="161">
+    <CharString index="183">
+        
+            -129 50 -662 -991 138 -40 return
+          
+    </CharString>
+    
+          
+    <CharString index="184">
         
             hintmask 1000010001001000111100010000100010101100
             return
@@ -1637,40 +1825,49 @@
     </CharString>
     
           
-    <CharString index="162">
+    <CharString index="185">
         
-            hintmask 1000010100001000111100010001000010101100
+            hintmask 1000010001010000111100010001000010101100
             return
           
     </CharString>
     
           
-    <CharString index="163">
+    <CharString index="186">
         
-            hintmask 1000010001000100111100010011000010101100
+            hintmask 1100010001001000111100010000100010101100
             return
           
     </CharString>
     
           
-    <CharString index="164">
+    <CharString index="187">
         
-            81 45 callsubr
+            81 66 callgsubr
             return
           
     </CharString>
     
           
-    <CharString index="165">
+    <CharString index="188">
         
-            61 callsubr
+            85 callsubr
+            hlineto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="189">
+        
+            86 callgsubr
             rlineto
             return
           
     </CharString>
     
           
-    <CharString index="166">
+    <CharString index="190">
         
             -184 rmoveto
             return
@@ -1678,32 +1875,67 @@
     </CharString>
     
           
-    <CharString index="167">
+    <CharString index="191">
         
-            142 rlinecurve
-            -184 -4 3 -121 return
+            6 -1 3 -4 -3 -2 -2 -7 vhcurveto
+            return
           
     </CharString>
     
           
-    <CharString index="168">
+    <CharString index="192">
+        
+            rlineto
+            -150 return
+          
+    </CharString>
+    
+          
+    <CharString index="193">
+        
+            hlineto
+            74 -73 -2 -13 -40 -25 rlineto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="194">
         
             rmoveto
-            -12 76 return
+            344 215 -63 122 return
           
     </CharString>
     
           
-    <CharString index="169">
+    <CharString index="195">
         
-            rmoveto
-            113 hlineto
-            108 285 return
+            186 rlineto
+            -188 hlineto
+            endchar
           
     </CharString>
     
           
-    <CharString index="170">
+    <CharString index="196">
+        
+            hlineto
+            5 callgsubr
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="197">
+        
+            hlineto
+            32 163 rlineto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="198">
         
             hvcurveto
             47 242 rlineto
@@ -1712,15 +1944,15 @@
     </CharString>
     
           
-    <CharString index="171">
+    <CharString index="199">
         
             rmoveto
-            131 3 6 return
+            131 3 return
           
     </CharString>
     
           
-    <CharString index="172">
+    <CharString index="200">
         
             rlineto
             207 hlineto
@@ -1729,7 +1961,7 @@
     </CharString>
     
           
-    <CharString index="173">
+    <CharString index="201">
         
             -11 123 return
           

--- a/ligature/OperatorMonoSSmLig-BoldItalic/subrs.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/subrs.xml
@@ -42,7 +42,7 @@
         
             rmoveto
             188 -97 76 -127 -196 -136 -212 -241 -188 96 -75 128 195 137 212 240 vhcurveto
-            -389 83 callsubr
+            -389 84 callsubr
             150 58 161 90 44 29 -38 -94 -150 -57 -161 -90 -45 -29 38 94 vhcurveto
             endchar
           
@@ -214,12 +214,12 @@
         
             -152 hlineto
             84 438 rlineto
-            4 callgsubr
+            4 callsubr
             23 125 rlineto
             -451 hlineto
             -24 66 callsubr
-            4 callgsubr
-            -84 -438 13 callgsubr
+            4 callsubr
+            -84 -438 13 callsubr
             -25 66 callsubr
             return
           
@@ -229,7 +229,7 @@
     <CharString index="19">
         
             rmoveto
-            106 -107 104 79 -177 40 callsubr
+            106 -107 104 79 -177 41 callgsubr
             -10 hlineto
             -248 -162 68 -76 rlineto
             return
@@ -272,7 +272,7 @@
             -5 hlineto
             77 468 -8 callgsubr
             -44 -293 -25 -263 -3 -132 rrcurveto
-            4 callgsubr
+            4 callsubr
             endchar
           
     </CharString>
@@ -363,7 +363,7 @@
             rmoveto
             144 2 95 396 -150 -5 -31 -138 rlineto
             -115 -30 -51 46 113 vvcurveto
-            138 66 159 95 47 12 -42 -97 -28 callsubr
+            138 66 159 95 47 12 -42 -97 -28 callgsubr
             11 -51 90 -135 hhcurveto
             -196 -158 -218 -242 -185 104 -97 191 36 hvcurveto
             return
@@ -411,7 +411,7 @@
     <CharString index="34">
         
             91 -92 78 -48 66 vhcurveto
-            111 111 -40 74 -96 80 callgsubr
+            111 111 -40 74 -96 80 callsubr
             -82 -87 -50 -86 -24 7 -24 12 -22 hvcurveto
             -36 -29 -51 -33 -68 -42 32 -68 rcurveline
             70 34 59 33 48 31 rrcurveto
@@ -471,7 +471,7 @@
     <CharString index="39">
         
             -225 -71 -89 41 145 vvcurveto
-            126 67 158 100 51 11 -37 -103 -28 callsubr
+            126 67 158 100 51 11 -37 -103 -28 callgsubr
             9 -49 90 -137 hhcurveto
             return
           
@@ -584,7 +584,7 @@
           
     <CharString index="48">
         
-            -19 callsubr
+            -19 callgsubr
             549 69 -98 callgsubr
             return
           
@@ -611,9 +611,10 @@
           
     <CharString index="51">
         
-            484 hlineto
-            27 140 -301 -3 376 417 22 134 72 callgsubr
-            -140 298 4 -381 -418 rlineto
+            454 hlineto
+            36 135 -284 -5 332 304 26 129 rlineto
+            -445 hlineto
+            -37 -136 277 6 -334 -304 rlineto
             endchar
           
     </CharString>
@@ -665,7 +666,7 @@
             61 316 -153 -11 -150 -773 rlineto
             151 hlineto
             67 347 rlineto
-            55 52 48 36 43 80 callgsubr
+            55 52 48 36 43 80 callsubr
             25 14 -12 -22 -38 -40 -60 -140 -91 hvcurveto
             return
           
@@ -685,8 +686,8 @@
             -36 -156 rlineto
             172 -18 86 -23 -61 vvcurveto
             -50 -56 -39 -148 -77 vhcurveto
-            48 -81 rlineto
-            239 116 94 94 94 vvcurveto
+            48 -81 86 callgsubr
+            116 94 94 94 vvcurveto
             109 -126 65 -273 27 vhcurveto
             return
           
@@ -729,8 +730,8 @@
           
     <CharString index="63">
         
-            -36 callsubr
-            -32 callsubr
+            -35 callgsubr
+            -31 callsubr
             return
           
     </CharString>
@@ -738,7 +739,7 @@
           
     <CharString index="64">
         
-            632 11 callsubr
+            632 11 callgsubr
             84 491 hintmask 10100000
             421 747 -53 callgsubr
             endchar
@@ -767,7 +768,7 @@
           
     <CharString index="66">
         
-            -18 callsubr
+            -18 callgsubr
             107 553 36 callgsubr
             return
           
@@ -793,8 +794,8 @@
           
     <CharString index="69">
         
-            -24 callgsubr
-            -36 callgsubr
+            -16 callgsubr
+            -32 callsubr
             return
           
     </CharString>
@@ -811,7 +812,9 @@
           
     <CharString index="71">
         
-            -13 131 87 82 168 124 return
+            -47 callsubr
+            hstem
+            return
           
     </CharString>
     
@@ -836,8 +839,8 @@
           
     <CharString index="73">
         
-            -75 -61 -158 -84 -12 callsubr
-            return
+            -12 callsubr
+            -17 1 -15 1 -15 return
           
     </CharString>
     
@@ -846,10 +849,10 @@
         
             8 callsubr
             hintmask 10110000
-            -132 -683 3 callgsubr
+            -132 -683 3 callsubr
             -159 -16 rmoveto
             hintmask 01110000
-            20 callsubr
+            20 callgsubr
             85 438 rlineto
             98 7 43 -52 -102 vvcurveto
             endchar
@@ -860,7 +863,7 @@
     <CharString index="75">
         
             hstem
-            54 149 230 146 vstem
+            48 157 217 71 callgsubr
             return
           
     </CharString>
@@ -869,7 +872,7 @@
     <CharString index="76">
         
             hstem
-            55 167 221 168 vstem
+            54 149 230 146 vstem
             return
           
     </CharString>
@@ -892,7 +895,7 @@
     <CharString index="78">
         
             -33 callgsubr
-            11 callgsubr
+            11 callsubr
             return
           
     </CharString>
@@ -900,16 +903,14 @@
           
     <CharString index="79">
         
-            -2 vhcurveto
-            150 2 rlineto
-            189 return
+            113 -52 111 74 110 return
           
     </CharString>
     
           
     <CharString index="80">
         
-            83 callgsubr
+            83 callsubr
             176 472 -84 callgsubr
             return
           
@@ -922,8 +923,8 @@
             121 139 vstem
             454 1 rmoveto
             -42 58 rlineto
-            -213 -60 -78 -77 -69 58 callsubr
-            0 callsubr
+            -213 -60 -78 -77 -69 56 callgsubr
+            -1 callsubr
             endchar
           
     </CharString>
@@ -974,28 +975,24 @@
           
     <CharString index="87">
         
-            -11 136 -136 139 hstemhm
-            211 261 return
+            -16 147 -37 callsubr
+            return
           
     </CharString>
     
           
     <CharString index="88">
         
-            151 hstem
-            124 12 callgsubr
-            vstem
-            return
+            -11 136 -136 139 hstemhm
+            211 261 return
           
     </CharString>
     
           
     <CharString index="89">
         
-            454 hlineto
-            26 135 rlineto
-            -292 hlineto
-            return
+            -17 callsubr
+            24 130 return
           
     </CharString>
     
@@ -1009,7 +1006,7 @@
           
     <CharString index="91">
         
-            643 66 callgsubr
+            643 67 callgsubr
             105 466 vstem
             356 644 -100 callgsubr
             endchar
@@ -1035,17 +1032,16 @@
           
     <CharString index="93">
         
-            623 251 hstem
-            155 363 vstem
-            155 -44 callgsubr
-            endchar
+            -107 -1322 380 hstem
+            -849 400 vstem
+            -449 -291 -90 callsubr
           
     </CharString>
     
           
     <CharString index="94">
         
-            -18 callgsubr
+            -18 callsubr
             rlineto
             return
           
@@ -1054,9 +1050,7 @@
           
     <CharString index="95">
         
-            vvcurveto
-            -91 84 -24 159 99 vhcurveto
-            return
+            -177 -186 -247 -306 return
           
     </CharString>
     
@@ -1082,15 +1076,15 @@
           
     <CharString index="98">
         
-            0 125 438 125 return
+            -12 133 314 129 return
           
     </CharString>
     
           
     <CharString index="99">
         
-            -9 callgsubr
-            1 callsubr
+            -9 callsubr
+            2 callgsubr
             return
           
     </CharString>
@@ -1108,9 +1102,8 @@
           
     <CharString index="101">
         
-            615 243 hstem
-            134 435 vstem
-            311 615 -82 callsubr
+            144 346 vstem
+            459 619 -95 callsubr
             endchar
           
     </CharString>
@@ -1142,7 +1135,7 @@
             362 hlineto
             25 122 rlineto
             -207 hlineto
-            141 733 93 callsubr
+            141 733 94 callgsubr
             24 122 rlineto
             endchar
           
@@ -1151,22 +1144,14 @@
           
     <CharString index="105">
         
-            -23 callgsubr
-            569 vstem
-            return
+            111 435 vstem
+            336 725 -88 callsubr
+            endchar
           
     </CharString>
     
           
     <CharString index="106">
-        
-            -15 144 433 141 18 callsubr
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="107">
         
             -15 -4 callgsubr
             32 52 40 142 30 vhcurveto
@@ -1175,10 +1160,19 @@
     </CharString>
     
           
+    <CharString index="107">
+        
+            -23 callgsubr
+            569 vstem
+            return
+          
+    </CharString>
+    
+          
     <CharString index="108">
         
             hstem
-            178 95 callgsubr
+            65 155 161 132 vstem
             return
           
     </CharString>
@@ -1186,10 +1180,7 @@
           
     <CharString index="109">
         
-            hlineto
-            30 callgsubr
-            -179 -22 callsubr
-            181 56 callgsubr
+            26 40 callsubr
             return
           
     </CharString>
@@ -1197,7 +1188,8 @@
           
     <CharString index="110">
         
-            98 180 95 hstem
+            rlineto
+            418 -53 149 235 250 vvcurveto
             return
           
     </CharString>
@@ -1205,17 +1197,15 @@
           
     <CharString index="111">
         
-            657 128 hstem
-            114 426 vstem
-            515 657 -64 callgsubr
-            endchar
+            146 hlineto
+            return
           
     </CharString>
     
           
     <CharString index="112">
         
-            644 66 callgsubr
+            644 67 callgsubr
             215 219 vstem
             215 643 -55 callgsubr
             endchar
@@ -1233,7 +1223,7 @@
           
     <CharString index="114">
         
-            -28 callgsubr
+            -28 callsubr
             hintmask 11011000
             return
           
@@ -1251,7 +1241,8 @@
           
     <CharString index="116">
         
-            -197 -162 -213 -236 return
+            -14 136 35 callgsubr
+            return
           
     </CharString>
     
@@ -1266,7 +1257,9 @@
           
     <CharString index="118">
         
-            115 -25 115 hstemhm
+            hstem
+            36 callsubr
+            vstem
             return
           
     </CharString>
@@ -1274,7 +1267,8 @@
           
     <CharString index="119">
         
-            -29 -40 15 32 vvcurveto
+            hlineto
+            -3 callgsubr
             return
           
     </CharString>
@@ -1282,24 +1276,27 @@
           
     <CharString index="120">
         
-            -14 24 121 -145 14 38 154 -148 13 -34 -153 -161 15 -25 -122 158 -15 return
+            rlineto
+            -145 hlineto
+            return
           
     </CharString>
     
           
     <CharString index="121">
         
-            -7 127 331 118 -117 122 hstemhm
-            16 158 76 144 114 141 hintmask 11011100
-            return
+            rmoveto
+            87 -121 289 225 38 154 -206 240 -111 -105 180 -201 rlineto
+            endchar
           
     </CharString>
     
           
     <CharString index="122">
         
-            -16 132 324 118 hstem
-            146 156 vstem
+            40 24 53 60 60 vhcurveto
+            16 callsubr
+            -29 -17 16 38 hvcurveto
             return
           
     </CharString>
@@ -1307,17 +1304,19 @@
           
     <CharString index="123">
         
-            -140 -179 -135 -175 -236 vhcurveto
-            87 14 rmoveto
-            183 94 136 123 90 69 return
+            18 -48 24 -51 30 -53 rrcurveto
+            -40 -44 -38 -15 -28 hhcurveto
+            return
           
     </CharString>
     
           
     <CharString index="124">
         
-            hstem
-            50 153 165 122 vstem
+            55 -62 63 38 vvcurveto
+            45 79 31 184 31 vhcurveto
+            -28 127 rlineto
+            -294 -70 -88 -92 -84 vvcurveto
             return
           
     </CharString>
@@ -1326,7 +1325,7 @@
     <CharString index="125">
         
             hstem
-            63 159 227 150 vstem
+            50 153 165 122 vstem
             return
           
     </CharString>
@@ -1334,8 +1333,8 @@
           
     <CharString index="126">
         
-            hstem
-            59 154 217 140 vstem
+            -14 120 hstem
+            294 160 vstem
             return
           
     </CharString>
@@ -1343,8 +1342,9 @@
           
     <CharString index="127">
         
-            -155 -77 -142 -149 6 vhcurveto
-            return
+            -9 callgsubr
+            hstem
+            28 return
           
     </CharString>
     
@@ -1361,7 +1361,9 @@
           
     <CharString index="129">
         
-            -4 -2 -3 -8 -9 2 -3 4 4 2 3 9 return
+            20 callsubr
+            583 vstem
+            return
           
     </CharString>
     
@@ -1376,7 +1378,7 @@
           
     <CharString index="131">
         
-            120 160 67 callgsubr
+            95 86 4 callgsubr
             return
           
     </CharString>
@@ -1399,6 +1401,17 @@
           
     <CharString index="134">
         
+            hhcurveto
+            55 1 -64 -75 -42 hvcurveto
+            65 -23 rlineto
+            164 132 -8 162 -140 hhcurveto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="135">
+        
             rmoveto
             -63 27 -83 -55 -63 -93 -16 -98 rlinecurve
             191 2 -6 68 12 83 28 66 rlinecurve
@@ -1407,20 +1420,12 @@
     </CharString>
     
           
-    <CharString index="135">
-        
-            vstem
-            55 hmoveto
-            -41 callsubr
-            return
-          
-    </CharString>
-    
-          
     <CharString index="136">
         
-            5 callgsubr
-            -518 -22 callsubr
+            rmoveto
+            84 callgsubr
+            33 168 rlineto
+            -181 hlineto
             return
           
     </CharString>
@@ -1428,8 +1433,8 @@
           
     <CharString index="137">
         
-            2 callgsubr
-            -519 -11 callsubr
+            26 134 rlineto
+            -339 62 callsubr
             return
           
     </CharString>
@@ -1437,7 +1442,10 @@
           
     <CharString index="138">
         
-            -14 144 -142 128 335 127 return
+            37 187 rlineto
+            -140 hlineto
+            -36 -187 rlineto
+            return
           
     </CharString>
     
@@ -1451,7 +1459,7 @@
           
     <CharString index="140">
         
-            0 174 71 callsubr
+            0 174 73 callsubr
             return
           
     </CharString>
@@ -1459,8 +1467,7 @@
           
     <CharString index="141">
         
-            hstem
-            68 95 callgsubr
+            100 240 105 hstem
             return
           
     </CharString>
@@ -1468,14 +1475,14 @@
           
     <CharString index="142">
         
-            385 163 return
+            101 244 99 return
           
     </CharString>
     
           
     <CharString index="143">
         
-            101 244 99 return
+            385 163 return
           
     </CharString>
     
@@ -1499,14 +1506,16 @@
           
     <CharString index="146">
         
-            88 280 95 return
+            rlineto
+            150 hlineto
+            return
           
     </CharString>
     
           
     <CharString index="147">
         
-            164 rlineto
+            131 rlineto
             return
           
     </CharString>
@@ -1523,7 +1532,8 @@
           
     <CharString index="149">
         
-            395 45 callsubr
+            94 callsubr
+            523 -19 callgsubr
             return
           
     </CharString>
@@ -1531,31 +1541,30 @@
           
     <CharString index="150">
         
-            122 733 122 hstem
-            return
+            -10 136 435 142 return
           
     </CharString>
     
           
     <CharString index="151">
         
-            -10 136 435 142 return
+            395 46 callgsubr
+            return
           
     </CharString>
     
           
     <CharString index="152">
         
-            rmoveto
-            5 callgsubr
-            return
+            132 hstemhm
+            441 159 return
           
     </CharString>
     
           
     <CharString index="153">
         
-            131 rlineto
+            269 134 hstem
             return
           
     </CharString>
@@ -1599,8 +1608,8 @@
           
     <CharString index="158">
         
-            301 642 rmoveto
-            167 7 47 157 -177 -9 rlineto
+            356 88 callsubr
+            -258 -167 rlineto
             return
           
     </CharString>
@@ -1608,8 +1617,8 @@
           
     <CharString index="159">
         
-            356 87 callsubr
-            -258 -167 rlineto
+            301 642 rmoveto
+            167 7 47 157 -177 -9 rlineto
             return
           
     </CharString>
@@ -1634,21 +1643,12 @@
           
     <CharString index="162">
         
-            24 130 rlineto
-            -152 -57 rmoveto
-            return
+            -35 -29 29 35 35 29 29 35 return
           
     </CharString>
     
           
     <CharString index="163">
-        
-            -190 141 502 124 return
-          
-    </CharString>
-    
-          
-    <CharString index="164">
         
             hstemhm
             41 154 154 149 return
@@ -1656,11 +1656,17 @@
     </CharString>
     
           
+    <CharString index="164">
+        
+            -190 141 502 124 return
+          
+    </CharString>
+    
+          
     <CharString index="165">
         
-            vvcurveto
-            -81 102 -51 194 91 vhcurveto
-            return
+            39 callgsubr
+            85 95 return
           
     </CharString>
     
@@ -1675,7 +1681,7 @@
           
     <CharString index="167">
         
-            hintmask 1000010001001000111100010001000010011100
+            hintmask 1000010001010000111100010000100010101100
             return
           
     </CharString>
@@ -1691,7 +1697,8 @@
           
     <CharString index="169">
         
-            88 119 73 hstem
+            hlineto
+            -27 -134 rlineto
             return
           
     </CharString>
@@ -1709,8 +1716,9 @@
           
     <CharString index="171">
         
-            586 51 82 callsubr
-            10 callsubr
+            rmoveto
+            1723 12 callsubr
+            -1723 hlineto
             return
           
     </CharString>
@@ -1737,13 +1745,6 @@
           
     <CharString index="174">
         
-            157 -46 147 -128 150 -101 141 return
-          
-    </CharString>
-    
-          
-    <CharString index="175">
-        
             -88 -2 -73 -375 rlineto
             86 hlineto
             42 217 rlineto
@@ -1752,9 +1753,19 @@
     </CharString>
     
           
+    <CharString index="175">
+        
+            -344 -215 63 -122 279 180 rlineto
+            return
+          
+    </CharString>
+    
+          
     <CharString index="176">
         
-            141 -101 150 -128 147 -46 157 return
+            62 123 36 83 vvcurveto
+            39 -25 36 -73 27 vhcurveto
+            return
           
     </CharString>
     
@@ -1769,8 +1780,8 @@
           
     <CharString index="178">
         
-            hstem
-            50 597 vstem
+            40 callgsubr
+            hstemhm
             return
           
     </CharString>
@@ -1778,8 +1789,8 @@
           
     <CharString index="179">
         
-            39 callsubr
-            hstemhm
+            hlineto
+            2 callsubr
             return
           
     </CharString>
@@ -1787,8 +1798,8 @@
           
     <CharString index="180">
         
-            26 callsubr
             hstem
+            50 597 vstem
             return
           
     </CharString>
@@ -1796,16 +1807,14 @@
           
     <CharString index="181">
         
-            82 -87 123 187 143 214 return
+            18 130 return
           
     </CharString>
     
           
     <CharString index="182">
         
-            -205 1209 hstem
-            -20 692 vstem
-            return
+            82 -87 123 187 143 214 return
           
     </CharString>
     
@@ -1827,7 +1836,7 @@
           
     <CharString index="185">
         
-            hintmask 1000010001010000111100010001000010101100
+            hintmask 1100010001001000111100010000100010101100
             return
           
     </CharString>
@@ -1835,7 +1844,7 @@
           
     <CharString index="186">
         
-            hintmask 1100010001001000111100010000100010101100
+            hintmask 1000010001000100111100010011000010101100
             return
           
     </CharString>
@@ -1843,7 +1852,8 @@
           
     <CharString index="187">
         
-            81 66 callgsubr
+            hhcurveto
+            hintmask 10100000
             return
           
     </CharString>
@@ -1851,8 +1861,8 @@
           
     <CharString index="188">
         
-            85 callsubr
-            hlineto
+            87 callgsubr
+            rlineto
             return
           
     </CharString>
@@ -1860,16 +1870,14 @@
           
     <CharString index="189">
         
-            86 callgsubr
-            rlineto
-            return
+            -215 1031 return
           
     </CharString>
     
           
     <CharString index="190">
         
-            -184 rmoveto
+            130 vstem
             return
           
     </CharString>
@@ -1877,7 +1885,7 @@
           
     <CharString index="191">
         
-            6 -1 3 -4 -3 -2 -2 -7 vhcurveto
+            -184 rmoveto
             return
           
     </CharString>
@@ -1885,22 +1893,30 @@
           
     <CharString index="192">
         
-            rlineto
-            -150 return
+            142 rlinecurve
+            -184 -4 3 -121 return
           
     </CharString>
     
           
     <CharString index="193">
         
-            hlineto
-            74 -73 -2 -13 -40 -25 rlineto
-            return
+            rlineto
+            -150 return
           
     </CharString>
     
           
     <CharString index="194">
+        
+            vvcurveto
+            -81 102 -51 193 91 vhcurveto
+            return
+          
+    </CharString>
+    
+          
+    <CharString index="195">
         
             rmoveto
             344 215 -63 122 return
@@ -1908,7 +1924,7 @@
     </CharString>
     
           
-    <CharString index="195">
+    <CharString index="196">
         
             186 rlineto
             -188 hlineto
@@ -1917,25 +1933,7 @@
     </CharString>
     
           
-    <CharString index="196">
-        
-            hlineto
-            5 callgsubr
-            return
-          
-    </CharString>
-    
-          
     <CharString index="197">
-        
-            hlineto
-            32 163 rlineto
-            return
-          
-    </CharString>
-    
-          
-    <CharString index="198">
         
             hvcurveto
             47 242 rlineto
@@ -1944,10 +1942,19 @@
     </CharString>
     
           
+    <CharString index="198">
+        
+            271 131 hstem
+            return
+          
+    </CharString>
+    
+          
     <CharString index="199">
         
-            rmoveto
-            131 3 return
+            hlineto
+            -74 -111 rlineto
+            return
           
     </CharString>
     
@@ -1955,7 +1962,7 @@
     <CharString index="200">
         
             rlineto
-            207 hlineto
+            84 callgsubr
             return
           
     </CharString>


### PR DESCRIPTION
This adds all the bold italic ligatures except for the following ligatures:

- greater_equal.2.liga
- greater_equal.liga
- less_equal.2.liga
- less_equal.liga
- percent.alt

I also updated the ampersand ampersand bold ligature to look better by rounding the bottom better.