### PR TITLE
Minor inconsistency in newly generated font names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
 node_modules
+.idea
 .vscode/launch.json
 .DS_Store

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ const patchNames = (dom, ligatures, profile) => {
   setAttribute(cffFont, 'FamilyName', 'value', familyNamePlat);
 
   // update existing names with new names
-  updateName(PlatformId.mac, NameId.familyName, familyName);
+  updateName(PlatformId.mac, NameId.familyName, familyNamePlat);
   updateName(PlatformId.mac, NameId.fontStyle, names.fontStyle);
   updateName(PlatformId.mac, NameId.uniqueId, uniqueId);
   updateName(PlatformId.mac, NameId.fullName, fullName);


### PR DESCRIPTION
The original font doesn't specify 'font weight' for this particular 'namerecord'. I am unsure whether this leads to any functional difference.
Left=Original, Right=Lig :
![image](https://user-images.githubusercontent.com/40262817/76235532-21e11d00-6223-11ea-83c6-5f677d881005.png)
