### PR TITLE
Adjust colon_equal for readability at smaller sizes

### DIFF
--- a/ligature/OperatorMonoSSmLig-Book/glyphs/colon_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-Book/glyphs/colon_equal.liga.xml
@@ -1,21 +1,23 @@
-<Glyph name="colon_equal.liga" lsb="-401" width="625">
+<Glyph name="colon_equal.liga" lsb="-395" width="625">
     <CharString>
-        0 129 39 77 169 77 hstem
-        -553 134 512 438 vstem
-        -401 388 rmoveto
+        141 130 -103 77 142 130 -103 77 hstemhm
+        -129 524 hintmask 01101000
+        -392 387 rmoveto
         133 hlineto
         2 130 rlineto
         -133 hlineto
-        779 -104 rmoveto
-        1 77 rlineto
-        -538 -77 hlineto
-        -244 -278 rmoveto
-        133 hlineto
+        hintmask 10101000
+        -5 -376 rmoveto
+        132 hlineto
         2 130 rlineto
         -133 hlineto
-        779 -98 rmoveto
+        hintmask 01011000
+        789 143 rmoveto
         1 77 rlineto
-        -538 -77 hlineto
+        -525 -77 hlineto
+        524 -246 rmoveto
+        1 77 rlineto
+        -525 -77 hlineto
         endchar
     </CharString>
     <Subrs/>

--- a/ligature/OperatorMonoSSmLig-BookItalic/glyphs/colon_equal.liga.xml
+++ b/ligature/OperatorMonoSSmLig-BookItalic/glyphs/colon_equal.liga.xml
@@ -1,23 +1,21 @@
-<Glyph name="colon_equal.liga" lsb="-408" width="625">
+<Glyph name="colon_equal.liga" lsb="-374" width="625">
     <CharString>
-        140 131 115 132 hstem
-        -408 851 vstem
-        -361 386 rmoveto
-        124 hlineto
-        26 132 rlineto
-        -124 hlineto
-        762 -104 rmoveto
+        168 76 170 76 -76 131 hstemhm
+        -374 149 49 561 -514 562 hintmask 11010100
+        417 414 rmoveto
         16 76 rlineto
-        -545 hlineto
+        -547 hlineto
         -15 -76 rlineto
-        -291 -274 rmoveto
-        124 hlineto
+        499 -246 rmoveto
+        hintmask 11011000
+        15 76 rlineto
+        -546 hlineto
+        -15 -76 rlineto
+        -198 246 rmoveto
+        123 hlineto
+        hintmask 10111000
         26 131 rlineto
         -124 hlineto
-        762 -103 rmoveto
-        15 76 rlineto
-        -544 hlineto
-        -15 -76 rlineto
         endchar
     </CharString>
     <Subrs/>


### PR DESCRIPTION
The colon and equals wasn't as readable at smaller sizes (which was noticable for me because I use a smaller font size). The characters have been separated slightly and the bars between the equals were separated slightly. 