### PR TITLE
Improve readme installation for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Which font weight of Operator Mono do you use? Also note difference between Scre
 - Python (v2.7+)
 - Node.js
 - Install _fonttools_ from https://github.com/fonttools/fonttools
-  - Windows/Linux: `pip install fonttools` **NOTE**: For Windows you should use a console with administrative permissions if your Python site under `C:\PythonX`
+  - Windows/Linux: `pip install fonttools` **NOTE**: For Windows you should use a console with administrative permissions if your Python sit under `C:\PythonX`
   - Mac: `pip3 install fonttools`
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Which font weight of Operator Mono do you use? Also note difference between Scre
 - Python (v2.7+)
 - Node.js
 - Install _fonttools_ from https://github.com/fonttools/fonttools
-  - Windows/Linux: `pip install fonttools`
+  - Windows/Linux: `pip install fonttools` **NOTE**: For Windows you should use a console with administrative permissions if your Python site under `C:\PythonX`
   - Mac: `pip3 install fonttools`
 
 ## Installation


### PR DESCRIPTION
I struggle a bit for Windows installation, turns out I require higher permissions when installing a pip package since I've my Python on `C:\` since not all of us are use to that, perhaps could be good to mention it.