### PR TITLE
Add pango & cairo as pre-reqs for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Which font weight of Operator Mono do you use? Also note difference between Scre
 - Node.js
 - Install _fonttools_ from https://github.com/fonttools/fonttools
   - Windows/Linux: `pip install fonttools` **NOTE**: For Windows you should use a console with administrative permissions if your Python sit under `C:\PythonX`
-  - Mac: `pip3 install fonttools`
+  - Mac: `brew install pango cairo; pip3 install fonttools`
 
 ## Installation
 


### PR DESCRIPTION
These two libraries are required by `canvas`, which in turn is required by `font-tools`.

See the following for more info on this error:
- https://github.com/Automattic/node-canvas/issues/599#issuecomment-377043217
- https://github.com/Automattic/node-canvas/issues/1050#issuecomment-351080589