### PR TITLE
Fix font weight/style metadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -291,6 +291,9 @@ const patchHmtx = (dom) => {
   copyConfigAttribute(dom, configDom, '/ttFont/hhea/advanceWidthMax', 'value');
   copyConfigAttribute(dom, configDom, '/ttFont/hhea/xMaxExtent', 'value');
   copyConfigAttribute(dom, configDom, '/ttFont/CFF/CFFFont/FontBBox', 'value');
+  copyConfigAttribute(dom, configDom, '/ttFont/head/macStyle', 'value');
+  copyConfigAttribute(dom, configDom, '/ttFont/OS_2/fsSelection', 'value');
+  copyConfigAttribute(dom, configDom, '/ttFont/OS_2/usWeightClass', 'value');
   copyConfigAttribute(
     dom,
     configDom,

--- a/ligature/OperatorMonoLig-Book/config.xml
+++ b/ligature/OperatorMonoLig-Book/config.xml
@@ -118,4 +118,8 @@
             </Private>
         </CFFFont>
     </CFF>
+    <OS_2>
+        <fsSelection value="00000000 01000000"/>
+        <usWeightClass value="400"/>
+    </OS_2>
 </ttFont>

--- a/ligature/OperatorMonoLig-BookItalic/config.xml
+++ b/ligature/OperatorMonoLig-BookItalic/config.xml
@@ -118,4 +118,8 @@
             </Private>
         </CFFFont>
     </CFF>
+    <OS_2>
+        <fsSelection value="00000000 00000001"/>
+        <usWeightClass value="400"/>
+    </OS_2>
 </ttFont>

--- a/ligature/OperatorMonoLig-Light/config.xml
+++ b/ligature/OperatorMonoLig-Light/config.xml
@@ -118,4 +118,8 @@
             </Private>
         </CFFFont>
     </CFF>
+    <OS_2>
+        <fsSelection value="00000000 01000000"/>
+        <usWeightClass value="300"/>
+    </OS_2>
 </ttFont>

--- a/ligature/OperatorMonoLig-LightItalic/config.xml
+++ b/ligature/OperatorMonoLig-LightItalic/config.xml
@@ -118,4 +118,8 @@
             </Private>
         </CFFFont>
     </CFF>
+    <OS_2>
+        <fsSelection value="00000000 00000001"/>
+        <usWeightClass value="300"/>
+    </OS_2>
 </ttFont>

--- a/ligature/OperatorMonoSSmLig-Bold/config.xml
+++ b/ligature/OperatorMonoSSmLig-Bold/config.xml
@@ -35,7 +35,7 @@
         <yMax value="1282"/>
         
     
-        <macStyle value="00000000 00000000"/>
+        <macStyle value="00000000 00000001"/>
         
     
         <lowestRecPPEM value="3"/>
@@ -118,4 +118,8 @@
             </Private>
         </CFFFont>
     </CFF>
+    <OS_2>
+        <fsSelection value="00000000 00100000"/>
+        <usWeightClass value="700"/>
+    </OS_2>
 </ttFont>

--- a/ligature/OperatorMonoSSmLig-BoldItalic/config.xml
+++ b/ligature/OperatorMonoSSmLig-BoldItalic/config.xml
@@ -35,7 +35,7 @@
         <yMax value="1271"/>
         
     
-        <macStyle value="00000000 00000010"/>
+        <macStyle value="00000000 00000011"/>
         
     
         <lowestRecPPEM value="3"/>
@@ -118,4 +118,8 @@
             </Private>
         </CFFFont>
     </CFF>
+    <OS_2>
+        <fsSelection value="00000000 00100001"/>
+        <usWeightClass value="700"/>
+    </OS_2>
 </ttFont>

--- a/ligature/OperatorMonoSSmLig-Book/config.xml
+++ b/ligature/OperatorMonoSSmLig-Book/config.xml
@@ -118,4 +118,8 @@
             </Private>
         </CFFFont>
     </CFF>
+    <OS_2>
+        <fsSelection value="00000000 01000000"/>
+        <usWeightClass value="400"/>
+    </OS_2>
 </ttFont>

--- a/ligature/OperatorMonoSSmLig-BookItalic/config.xml
+++ b/ligature/OperatorMonoSSmLig-BookItalic/config.xml
@@ -118,4 +118,8 @@
             </Private>
         </CFFFont>
     </CFF>
+    <OS_2>
+        <fsSelection value="00000000 00000001"/>
+        <usWeightClass value="400"/>
+    </OS_2>
 </ttFont>

--- a/ligature/OperatorMonoSSmLig-Light/config.xml
+++ b/ligature/OperatorMonoSSmLig-Light/config.xml
@@ -118,4 +118,8 @@
             </Private>
         </CFFFont>
     </CFF>
+    <OS_2>
+        <fsSelection value="00000000 01000000"/>
+        <usWeightClass value="300"/>
+    </OS_2>
 </ttFont>

--- a/ligature/OperatorMonoSSmLig-LightItalic/config.xml
+++ b/ligature/OperatorMonoSSmLig-LightItalic/config.xml
@@ -118,4 +118,8 @@
             </Private>
         </CFFFont>
     </CFF>
+    <OS_2>
+        <fsSelection value="00000000 00000001"/>
+        <usWeightClass value="300"/>
+    </OS_2>
 </ttFont>

--- a/ligature/OperatorMonoSSmLig-Medium/config.xml
+++ b/ligature/OperatorMonoSSmLig-Medium/config.xml
@@ -118,4 +118,8 @@
             </Private>
         </CFFFont>
     </CFF>
+    <OS_2>
+        <fsSelection value="00000000 01000000"/>
+        <usWeightClass value="500"/>
+    </OS_2>
 </ttFont>

--- a/ligature/OperatorMonoSSmLig-MediumItalic/config.xml
+++ b/ligature/OperatorMonoSSmLig-MediumItalic/config.xml
@@ -118,4 +118,8 @@
             </Private>
         </CFFFont>
     </CFF>
+    <OS_2>
+        <fsSelection value="00000000 00000001"/>
+        <usWeightClass value="500"/>
+    </OS_2>
 </ttFont>


### PR DESCRIPTION
This fixes a bug that Bold is interpreted as a standard font style (instead of Book) by some applications and operating systems.

This sets correct values to following metadata:
* head: macStyle: https://learn.microsoft.com/en-us/typography/opentype/spec/head
* OS/2: fsSelection: https://learn.microsoft.com/en-us/typography/opentype/spec/os2#fsselection
* OS/2: usWeightClass: https://learn.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass